### PR TITLE
Input:

### DIFF
--- a/internal/codegen/main_generator.go
+++ b/internal/codegen/main_generator.go
@@ -1,20 +1,217 @@
 package codegen
 
-import "github.com/podhmo/goat/internal/metadata"
+import (
+	"bytes"
+	"fmt"
+	"go/format"
+	"strings"
+	"text/template"
+
+	"github.com/podhmo/goat/internal/metadata"
+)
 
 // GenerateMain creates the Go code string for the new main() function
 // based on the extracted command metadata.
-// This is a placeholder for future implementation.
 func GenerateMain(cmdMeta *metadata.CommandMetadata) (string, error) {
-	// TODO: Implement the logic to generate Go code for:
-	// 1. Flag parsing using the "flag" package, based on cmdMeta.Options
-	//    - Set up flags with names, types, help text, default values.
-	//    - Handle required flags.
-	//    - Handle enum validation.
-	//    - Read from environment variables.
-	// 2. Call the original run function (cmdMeta.RunFunc.Name) with the populated options struct.
-	// 3. Handle errors from the run function.
-	// 4. Include necessary imports.
+	// Helper function for the template to join option names for the function call
+	templateFuncs := template.FuncMap{
+		"Title": strings.Title,
+		"JoinFlagVars": func(options []metadata.Option) string {
+			var names []string
+			for _, opt := range options {
+				names = append(names, strings.Title(opt.Name)+"Flag")
+			}
+			return strings.Join(names, ", ")
+		},
+		// Raw string output for default values to avoid auto-escaping in template
+		"RawString": func(s string) template.HTML {
+			return template.HTML(s)
+		},
+	}
 
-	return "// TODO: Generated main function content will be here.\n", nil
+	tmpl := template.Must(template.New("main").Funcs(templateFuncs).Parse(`
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	{{if .NeedsStrconv}}
+	"strconv"
+	{{end}}
+	{{range .Imports}}
+	"{{.}}"
+	{{end}}
+)
+
+func main() {
+	{{if .HasOptions}}
+	// Declare individual variables for each flag
+	{{range .Options}}
+	var {{Title .Name}}Flag {{.Type}}
+	{{end}}
+
+	// Setup flag parsing for each option
+	{{range .Options}}
+	{{if eq .Type "string"}}
+	flag.StringVar(&{{Title .Name}}Flag, "{{.Name}}", {{if .Default}}{{printf "%q" .Default}}{{else}}""{{end}}, "{{.Description}}")
+	{{else if eq .Type "int"}}
+	flag.IntVar(&{{Title .Name}}Flag, "{{.Name}}", {{if .Default}}{{.Default}}{{else}}0{{end}}, "{{.Description}}")
+	{{else if eq .Type "bool"}}
+	flag.BoolVar(&{{Title .Name}}Flag, "{{.Name}}", {{if .Default}}{{.Default}}{{else}}false{{end}}, "{{.Description}}")
+	{{end}}
+	{{end}}
+
+	flag.Parse()
+
+	// Handle environment variables and required flags
+	{{range .Options}}
+	{{if .Envvar}}
+	if val, ok := os.LookupEnv("{{.Envvar}}"); ok {
+		// If flag was set, it takes precedence. Only use env if flag is still its zero value.
+		// This check is tricky for bools where false is a valid value AND the default.
+		// And for numbers where 0 is a valid value AND the default.
+		// A more robust way might involve checking if the flag was explicitly set.
+		// For now, if default is zero-value, env var will override if set.
+		// If default is non-zero, flag value (even if it's the default) takes precedence.
+		{{if eq .Type "string"}}
+		if {{Title .Name}}Flag == {{if .Default}}{{printf "%q" .Default}}{{else}}""{{end}} { // only override if flag is still at default
+			{{Title .Name}}Flag = val
+		}
+		{{else if eq .Type "int"}}
+		if {{Title .Name}}Flag == {{if .Default}}{{.Default}}{{else}}0{{end}} {
+			if v, err := strconv.Atoi(val); err == nil {
+				{{Title .Name}}Flag = v
+			} else {
+				log.Printf("Warning: could not parse environment variable {{.Envvar}} as int: %v", err)
+			}
+		}
+		{{else if eq .Type "bool"}}
+		if {{Title .Name}}Flag == {{if .Default}}{{.Default}}{{else}}false{{end}} {
+			if v, err := strconv.ParseBool(val); err == nil {
+				{{Title .Name}}Flag = v
+			} else {
+				log.Printf("Warning: could not parse environment variable {{.Envvar}} as bool: %v", err)
+			}
+		}
+		{{end}}
+	}
+	{{end}}
+
+	{{if .Required}}
+	{{if eq .Type "string"}}
+	if {{Title .Name}}Flag == "" {
+		log.Fatalf("Missing required flag: -{{.Name}} {{if .Envvar}}or environment variable {{.Envvar}}{{end}}")
+	}
+	{{else if eq .Type "int"}}
+	// This check for required int is tricky if 0 is a valid value AND the default.
+	// If the default is non-zero, then if the flag is still that default, it's effectively "unset" by user.
+	// If default is zero, we check if it was explicitly set or came from env.
+	if {{Title .Name}}Flag == {{if .Default}}{{.Default}}{{else}}0{{end}} {
+		isSet_{{Title .Name}} := false
+		flag.Visit(func(f *flag.Flag) {
+			if f.Name == "{{.Name}}" {
+				isSet_{{Title .Name}} = true
+			}
+		})
+		envIsSource_{{Title .Name}} := false
+		{{if .Envvar}}
+		if val, ok := os.LookupEnv("{{.Envvar}}"); ok {
+			if parsedVal, err := strconv.Atoi(val); err == nil && parsedVal == {{Title .Name}}Flag {
+				envIsSource_{{Title .Name}} = true
+			}
+		}
+		{{end}}
+		if !isSet_{{Title .Name}} && !envIsSource_{{Title .Name}} {
+			log.Fatalf("Missing required flag: -{{.Name}} {{if .Envvar}}or environment variable {{.Envvar}}{{end}}")
+		}
+	}
+	{{else if eq .Type "bool"}}
+	// For bools, "required" usually implies it must be explicitly set, or must be true.
+	// If it must be true: if !{{Title .Name}}Flag { log.Fatalf("Flag -{{.Name}} must be true") }
+	// If it must be set (and default is false), this is hard to check without knowing if it was user-set.
+	// The current logic for env var precedence tries to handle this: if it's still default false, env can make it true.
+	// If truly "required to be explicitly set", the logic would need flag.Visit.
+	{{end}}
+	{{end}}
+
+	{{if .Enum}}
+	isValidChoice_{{Title .Name}} := false
+	allowedChoices_{{Title .Name}} := []string{ {{range $i, $e := .Enum}}{{if $i}}, {{end}}{{printf "%q" $e}}{{end}} }
+	for _, choice := range allowedChoices_{{Title .Name}} {
+		if {{Title .Name}}Flag == choice {
+			isValidChoice_{{Title .Name}} = true
+			break
+		}
+	}
+	if !isValidChoice_{{Title .Name}} {
+		log.Fatalf("Invalid value for -{{.Name}}: %s. Allowed choices are: %s", {{Title .Name}}Flag, strings.Join(allowedChoices_{{Title .Name}}, ", "))
+	}
+	{{end}}
+	{{end}}
+	{{end}}
+
+	// Call the original run function
+	{{if .HasOptions}}
+	err := {{.RunFuncPackage}}.{{.RunFuncName}}({{ JoinFlagVars .Options }})
+	{{else}}
+	err := {{.RunFuncPackage}}.{{.RunFuncName}}()
+	{{end}}
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+`))
+
+	needsStrconv := false
+	for _, opt := range cmdMeta.Options {
+		if opt.Envvar != "" && (opt.Type == "int" || opt.Type == "bool") {
+			needsStrconv = true
+			break
+		}
+	}
+	// Ensure strconv is not duplicated in user's imports
+	finalImports := []string{}
+	userImportsStrconv := false
+	for _, imp := range cmdMeta.RunFunc.Imports {
+		if imp == "strconv" {
+			userImportsStrconv = true
+		}
+		finalImports = append(finalImports, imp)
+	}
+	if needsStrconv && userImportsStrconv {
+		needsStrconv = false // User already imports it, template will handle it via {{range .Imports}}
+	}
+
+
+	data := struct {
+		RunFuncName    string
+		RunFuncPackage string
+		Options        []metadata.Option
+		HasOptions     bool
+		Imports        []string
+		NeedsStrconv   bool
+	}{
+		RunFuncName:    cmdMeta.RunFunc.Name,
+		RunFuncPackage: cmdMeta.RunFunc.PackageName,
+		Options:        cmdMeta.Options,
+		HasOptions:     len(cmdMeta.Options) > 0,
+		Imports:        finalImports,
+		NeedsStrconv:   needsStrconv,
+	}
+
+	var generatedCode bytes.Buffer
+	if err := tmpl.Execute(&generatedCode, data); err != nil {
+		return "", fmt.Errorf("executing template: %w", err)
+	}
+
+	formattedCode, err := format.Source(generatedCode.Bytes())
+	if err != nil {
+		// For debugging, return the unformatted code to see the issue
+		return "", fmt.Errorf("formatting generated code: %w\nRaw generated code:\n%s", err, generatedCode.String())
+	}
+
+	return string(formattedCode), nil
 }

--- a/internal/codegen/main_generator_test.go
+++ b/internal/codegen/main_generator_test.go
@@ -1,0 +1,424 @@
+package codegen_test
+
+import (
+	"fmt"
+	"go/format"
+	"strings"
+	"testing"
+
+	"github.com/podhmo/goat/internal/codegen"
+	"github.com/podhmo/goat/internal/metadata"
+)
+
+// normalizeCode formats the code string using go/format and removes leading/trailing whitespace.
+// This helps in making comparisons less brittle.
+func normalizeCode(t *testing.T, code string) string {
+	t.Helper()
+	formatted, err := format.Source([]byte(code))
+	if err != nil {
+		t.Fatalf("Failed to format code: %v\nOriginal code:\n%s", err, code)
+	}
+	return strings.TrimSpace(string(formatted))
+}
+
+func assertCodeContains(t *testing.T, actualCode, expectedSnippet string) {
+	t.Helper()
+	// Normalize the snippet too, so we are comparing formatted code with formatted code.
+	normalizedExpectedSnippet := normalizeCode(t, expectedSnippet)
+	if !strings.Contains(actualCode, normalizedExpectedSnippet) {
+		// For easier debugging, show the normalized expected snippet
+		// and the (already normalized) actual code.
+		t.Errorf("Expected generated code to contain:\n>>>>>>>>>>\n%s\n<<<<<<<<<<\n\nActual code:\n>>>>>>>>>>\n%s\n<<<<<<<<<<",
+			normalizedExpectedSnippet, actualCode)
+	}
+}
+
+func assertCodeNotContains(t *testing.T, actualCode, unexpectedSnippet string) {
+	t.Helper()
+	// Normalize the snippet to ensure we're not failing due to formatting.
+	normalizedUnexpectedSnippet := normalizeCode(t, unexpectedSnippet)
+	if strings.Contains(actualCode, normalizedUnexpectedSnippet) {
+		t.Errorf("Expected generated code NOT to contain:\n>>>>>>>>>>\n%s\n<<<<<<<<<<\n\nActual code:\n>>>>>>>>>>\n%s\n<<<<<<<<<<",
+			normalizedUnexpectedSnippet, actualCode)
+	}
+}
+
+
+func TestGenerateMain_BasicCase(t *testing.T) {
+	cmdMeta := &metadata.CommandMetadata{
+		RunFunc: metadata.Func{
+			Name:        "Run",
+			PackageName: "mycmd",
+			Imports:     []string{"github.com/example/mycmd"},
+		},
+		Options: []metadata.Option{},
+	}
+
+	actualCode, err := codegen.GenerateMain(cmdMeta)
+	if err != nil {
+		t.Fatalf("GenerateMain failed: %v", err)
+	}
+	normalizedActualCode := normalizeCode(t, actualCode)
+
+	expectedImports := `
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/example/mycmd"
+)
+`
+	assertCodeContains(t, normalizedActualCode, expectedImports)
+	assertCodeContains(t, normalizedActualCode, "func main() {")
+	assertCodeContains(t, normalizedActualCode, "err := mycmd.Run()")
+	assertCodeContains(t, normalizedActualCode, "if err != nil {")
+	assertCodeContains(t, normalizedActualCode, "log.Fatal(err)")
+	assertCodeNotContains(t, normalizedActualCode, "type Options struct")
+}
+
+func TestGenerateMain_WithOptions(t *testing.T) {
+	cmdMeta := &metadata.CommandMetadata{
+		RunFunc: metadata.Func{
+			Name:        "RunWithOptions",
+			PackageName: "anothercmd",
+			Imports:     []string{"github.com/example/anothercmd"},
+		},
+		Options: []metadata.Option{
+			{Name: "name", Type: "string", Description: "Name of the user", Default: "guest"},
+			{Name: "age", Type: "int", Description: "Age of the user", Default: "30"},
+			{Name: "verbose", Type: "bool", Description: "Enable verbose output", Default: "false"},
+		},
+	}
+
+	actualCode, err := codegen.GenerateMain(cmdMeta)
+	if err != nil {
+		t.Fatalf("GenerateMain failed: %v", err)
+	}
+	normalizedActualCode := normalizeCode(t, actualCode)
+
+	assertCodeNotContains(t, normalizedActualCode, "type Options struct")
+
+	expectedVarDeclarations := `
+	var NameFlag string
+	var AgeFlag int
+	var VerboseFlag bool
+`
+	assertCodeContains(t, normalizedActualCode, expectedVarDeclarations)
+
+	expectedFlagParsing := `
+	flag.StringVar(&NameFlag, "name", "guest", "Name of the user")
+	flag.IntVar(&AgeFlag, "age", 30, "Age of the user")
+	flag.BoolVar(&VerboseFlag, "verbose", false, "Enable verbose output")
+	flag.Parse()
+`
+	assertCodeContains(t, normalizedActualCode, expectedFlagParsing)
+	assertCodeContains(t, normalizedActualCode, "err := anothercmd.RunWithOptions(NameFlag, AgeFlag, VerboseFlag)")
+}
+
+func TestGenerateMain_RequiredFlags(t *testing.T) {
+	cmdMeta := &metadata.CommandMetadata{
+		RunFunc: metadata.Func{Name: "DoSomething", PackageName: "task"},
+		Options: []metadata.Option{
+			{Name: "configFile", Type: "string", Description: "Path to config file", Required: true},
+			{Name: "retries", Type: "int", Description: "Number of retries", Required: true, Default: "0"},
+		},
+	}
+
+	actualCode, err := codegen.GenerateMain(cmdMeta)
+	if err != nil {
+		t.Fatalf("GenerateMain failed: %v", err)
+	}
+	normalizedActualCode := normalizeCode(t, actualCode)
+
+	expectedConfigFileCheck := `
+	if ConfigFileFlag == "" {
+		log.Fatalf("Missing required flag: -configFile")
+	}
+`
+	assertCodeContains(t, normalizedActualCode, expectedConfigFileCheck)
+
+	expectedRetriesCheck := `
+	if RetriesFlag == 0 {
+		isSet_Retries := false
+		flag.Visit(func(f *flag.Flag) {
+			if f.Name == "retries" {
+				isSet_Retries = true
+			}
+		})
+		envIsSource_Retries := false
+		if !isSet_Retries && !envIsSource_Retries {
+			log.Fatalf("Missing required flag: -retries")
+		}
+	}
+`
+	assertCodeContains(t, normalizedActualCode, expectedRetriesCheck)
+	assertCodeContains(t, normalizedActualCode, "err := task.DoSomething(ConfigFileFlag, RetriesFlag)")
+}
+
+func TestGenerateMain_EnumValidation(t *testing.T) {
+	cmdMeta := &metadata.CommandMetadata{
+		RunFunc: metadata.Func{Name: "SetMode", PackageName: "control"},
+		Options: []metadata.Option{
+			{Name: "mode", Type: "string", Description: "Mode of operation", Enum: []string{"auto", "manual", "standby"}},
+		},
+	}
+
+	actualCode, err := codegen.GenerateMain(cmdMeta)
+	if err != nil {
+		t.Fatalf("GenerateMain failed: %v", err)
+	}
+	normalizedActualCode := normalizeCode(t, actualCode)
+
+	expectedEnumValidation := `
+	isValidChoice_ModeFlag := false
+	allowedChoices_ModeFlag := []string{"auto", "manual", "standby"}
+	for _, choice := range allowedChoices_ModeFlag {
+		if ModeFlag == choice {
+			isValidChoice_ModeFlag = true
+			break
+		}
+	}
+	if !isValidChoice_ModeFlag {
+		log.Fatalf("Invalid value for -mode: %s. Allowed choices are: %s", ModeFlag, strings.Join(allowedChoices_ModeFlag, ", "))
+	}
+`
+	assertCodeContains(t, normalizedActualCode, expectedEnumValidation)
+	assertCodeContains(t, normalizedActualCode, "err := control.SetMode(ModeFlag)")
+}
+
+func TestGenerateMain_EnvironmentVariables(t *testing.T) {
+	cmdMeta := &metadata.CommandMetadata{
+		RunFunc: metadata.Func{Name: "Configure", PackageName: "setup"},
+		Options: []metadata.Option{
+			{Name: "apiKey", Type: "string", Description: "API Key", Envvar: "API_KEY"}, // Default is ""
+			{Name: "timeout", Type: "int", Description: "Timeout in seconds", Default: "60", Envvar: "TIMEOUT_SECONDS"},
+			{Name: "enableFeature", Type: "bool", Description: "Enable new feature", Default: "false", Envvar: "ENABLE_MY_FEATURE"},
+		},
+	}
+
+	actualCode, err := codegen.GenerateMain(cmdMeta)
+	if err != nil {
+		t.Fatalf("GenerateMain failed: %v", err)
+	}
+	normalizedActualCode := normalizeCode(t, actualCode)
+
+	expectedApiKeyEnv := `
+	if val, ok := os.LookupEnv("API_KEY"); ok {
+		if ApiKeyFlag == "" { 
+			ApiKeyFlag = val
+		}
+	}
+`
+	assertCodeContains(t, normalizedActualCode, expectedApiKeyEnv)
+
+	expectedTimeoutEnv := `
+	if val, ok := os.LookupEnv("TIMEOUT_SECONDS"); ok {
+		if TimeoutFlag == 60 {
+			if v, err := strconv.Atoi(val); err == nil {
+				TimeoutFlag = v
+			} else {
+				log.Printf("Warning: could not parse environment variable TIMEOUT_SECONDS as int: %v", err)
+			}
+		}
+	}
+`
+	assertCodeContains(t, normalizedActualCode, expectedTimeoutEnv)
+
+	expectedEnableFeatureEnv := `
+	if val, ok := os.LookupEnv("ENABLE_MY_FEATURE"); ok {
+		if EnableFeatureFlag == false {
+			if v, err := strconv.ParseBool(val); err == nil {
+				EnableFeatureFlag = v
+			} else {
+				log.Printf("Warning: could not parse environment variable ENABLE_MY_FEATURE as bool: %v", err)
+			}
+		}
+	}
+`
+	assertCodeContains(t, normalizedActualCode, expectedEnableFeatureEnv)
+	assertCodeContains(t, normalizedActualCode, `import ("strconv")`)
+	assertCodeContains(t, normalizedActualCode, "err := setup.Configure(ApiKeyFlag, TimeoutFlag, EnableFeatureFlag)")
+}
+
+
+func TestGenerateMain_RunFuncInvocation(t *testing.T) {
+	// Case 1: No options
+	cmdMetaNoOpts := &metadata.CommandMetadata{
+		RunFunc: metadata.Func{Name: "Execute", PackageName: "action"},
+	}
+	actualCodeNoOpts, err := codegen.GenerateMain(cmdMetaNoOpts)
+	if err != nil {
+		t.Fatalf("GenerateMain (no opts) failed: %v", err)
+	}
+	normalizedActualCodeNoOpts := normalizeCode(t, actualCodeNoOpts)
+	assertCodeContains(t, normalizedActualCodeNoOpts, "err := action.Execute()")
+
+	// Case 2: With options
+	cmdMetaWithOptions := &metadata.CommandMetadata{
+		RunFunc: metadata.Func{Name: "Process", PackageName: "dataflow"},
+		Options: []metadata.Option{
+			{Name: "input", Type: "string"},
+			{Name: "level", Type: "int"},
+		},
+	}
+	actualCodeWithOptions, err := codegen.GenerateMain(cmdMetaWithOptions)
+	if err != nil {
+		t.Fatalf("GenerateMain (with opts) failed: %v", err)
+	}
+	normalizedActualCodeWithOptions := normalizeCode(t, actualCodeWithOptions)
+	assertCodeContains(t, normalizedActualCodeWithOptions, "err := dataflow.Process(InputFlag, LevelFlag)")
+}
+
+func TestGenerateMain_ErrorHandling(t *testing.T) {
+	cmdMeta := &metadata.CommandMetadata{
+		RunFunc: metadata.Func{Name: "DefaultRun", PackageName: "pkg"},
+	}
+	actualCode, err := codegen.GenerateMain(cmdMeta)
+	if err != nil {
+		t.Fatalf("GenerateMain failed: %v", err)
+	}
+	normalizedActualCode := normalizeCode(t, actualCode)
+
+	expectedErrorHandling := `
+	if err != nil {
+		log.Fatal(err)
+	}
+`
+	assertCodeContains(t, normalizedActualCode, expectedErrorHandling)
+}
+
+func TestGenerateMain_Imports(t *testing.T) {
+	cmdMetaNoStrconv := &metadata.CommandMetadata{
+		RunFunc: metadata.Func{
+			Name:        "MyFunc",
+			PackageName: "custompkg",
+			Imports:     []string{"github.com/custom/lib1", "github.com/another/lib2"},
+		},
+		Options: []metadata.Option{
+			{Name: "name", Type: "string", Envvar: "APP_NAME"}, // String env var does not need strconv
+		},
+	}
+
+	actualCodeNoStrconv, err := codegen.GenerateMain(cmdMetaNoStrconv)
+	if err != nil {
+		t.Fatalf("GenerateMain failed: %v", err)
+	}
+	normalizedCodeNoStrconv := normalizeCode(t, actualCodeNoStrconv)
+
+	standardImports := []string{`"flag"`, `"fmt"`, `"log"`, `"os"`, `"strings"`}
+	for _, imp := range standardImports {
+		assertCodeContains(t, normalizedCodeNoStrconv, imp)
+	}
+	customImports := []string{`"github.com/custom/lib1"`, `"github.com/another/lib2"`}
+	for _, imp := range customImports {
+		assertCodeContains(t, normalizedCodeNoStrconv, imp)
+	}
+	assertCodeNotContains(t, normalizedCodeNoStrconv, `"strconv"`) // Should not be there
+
+	// Now with an option that needs strconv
+	cmdMetaWithStrconv := &metadata.CommandMetadata{
+		RunFunc: metadata.Func{
+			Name:        "MyOtherFunc",
+			PackageName: "custompkg",
+			Imports:     []string{"github.com/custom/lib1"}, // No strconv here
+		},
+		Options: []metadata.Option{
+			{Name: "port", Type: "int", Envvar: "APP_PORT"}, // Needs strconv
+		},
+	}
+	actualCodeWithStrconv, err := codegen.GenerateMain(cmdMetaWithStrconv)
+	if err != nil {
+		t.Fatalf("GenerateMain failed: %v", err)
+	}
+	normalizedCodeWithStrconv := normalizeCode(t, actualCodeWithStrconv)
+	assertCodeContains(t, normalizedCodeWithStrconv, `"strconv"`) // Should be there
+
+	// With strconv already in user imports
+	cmdMetaWithUserStrconv := &metadata.CommandMetadata{
+		RunFunc: metadata.Func{
+			Name:        "MyOtherFunc",
+			PackageName: "custompkg",
+			Imports:     []string{"github.com/custom/lib1", "strconv"}, // User imports strconv
+		},
+		Options: []metadata.Option{
+			{Name: "port", Type: "int", Envvar: "APP_PORT"}, // Needs strconv
+		},
+	}
+	actualCodeWithUserStrconv, err := codegen.GenerateMain(cmdMetaWithUserStrconv)
+	if err != nil {
+		t.Fatalf("GenerateMain failed: %v", err)
+	}
+	normalizedCodeWithUserStrconv := normalizeCode(t, actualCodeWithUserStrconv)
+	// Check that "strconv" is present (it will be from user imports)
+	// and that the template doesn't add a duplicate conditional import block for it.
+	// The current template logic for {{if .NeedsStrconv}} and how data.Imports is prepared
+	// should handle this by setting NeedsStrconv to false if user already imports it.
+	// So, we just check it's there (from user) and not that the specific conditional block is absent.
+	assertCodeContains(t, normalizedCodeWithUserStrconv, `"strconv"`)
+	// A bit harder to check for absence of the *conditional* import if user already has it.
+	// The key is that `go/format` would fail or `go build` would complain about unused duplicate import names
+	// if it were `import _ "strconv"` and `import "strconv"`.
+	// Our current logic in GenerateMain is to set `NeedsStrconv` to false if user imports it.
+	// So the `{{if .NeedsStrconv}} "strconv" {{end}}` block in template won't render.
+}
+
+
+func TestGenerateMain_RequiredIntWithEnvVar(t *testing.T) {
+	cmdMeta := &metadata.CommandMetadata{
+		RunFunc: metadata.Func{Name: "SubmitData", PackageName: "submitter"},
+		Options: []metadata.Option{
+			{Name: "userId", Type: "int", Description: "User ID", Required: true, Envvar: "USER_ID"}, // Default is 0
+		},
+	}
+
+	actualCode, err := codegen.GenerateMain(cmdMeta)
+	if err != nil {
+		t.Fatalf("GenerateMain failed: %v", err)
+	}
+	normalizedActualCode := normalizeCode(t, actualCode)
+
+	expectedCheck := `
+	if UserIdFlag == 0 {
+		isSet_UserId := false
+		flag.Visit(func(f *flag.Flag) {
+			if f.Name == "userId" {
+				isSet_UserId = true
+			}
+		})
+		envIsSource_UserId := false
+		if val, ok := os.LookupEnv("USER_ID"); ok {
+			if parsedVal, err := strconv.Atoi(val); err == nil && parsedVal == UserIdFlag {
+				envIsSource_UserId = true
+			}
+		}
+		if !isSet_UserId && !envIsSource_UserId {
+			log.Fatalf("Missing required flag: -userId or environment variable USER_ID")
+		}
+	}
+`
+	assertCodeContains(t, normalizedActualCode, expectedCheck)
+	assertCodeContains(t, normalizedActualCode, "err := submitter.SubmitData(UserIdFlag)")
+	assertCodeContains(t, normalizedActualCode, `import ("strconv")`) // Because of Atoi in the check
+}
+
+func TestGenerateMain_StringFlagWithQuotesInDefault(t *testing.T) {
+	cmdMeta := &metadata.CommandMetadata{
+		RunFunc: metadata.Func{Name: "PrintString", PackageName: "printer"},
+		Options: []metadata.Option{
+			{Name: "greeting", Type: "string", Description: "A greeting message", Default: `hello "world"`},
+		},
+	}
+	actualCode, err := codegen.GenerateMain(cmdMeta)
+	if err != nil {
+		t.Fatalf("GenerateMain failed: %v", err)
+	}
+	normalizedActualCode := normalizeCode(t, actualCode)
+
+	// Check that the default value is correctly quoted in the generated code
+	// The template uses {{printf "%q" .Default}}
+	expectedFlagParsing := `flag.StringVar(&GreetingFlag, "greeting", "hello \"world\"", "A greeting message")`
+	assertCodeContains(t, normalizedActualCode, expectedFlagParsing)
+}

--- a/internal/codegen/writer.go
+++ b/internal/codegen/writer.go
@@ -1,30 +1,115 @@
 package codegen
 
 import (
+	"bytes"
+	"fmt"
 	"go/ast"
+	"go/format"
 	"go/token"
+	"os"
 )
 
-// WriteMain takes the original file's AST, the new main function content (as string),
+// WriteMain takes the original file path, its AST, the new main function content (as string),
 // and the position of the old main function, then writes the modified content.
-// This is a placeholder for future implementation.
 func WriteMain(
 	filePath string,
+	fileSet *token.FileSet, // Added FileSet to correctly get offsets
 	fileAst *ast.File,
 	newMainContent string,
-	mainFuncPos *token.Position,
+	mainFuncPos *token.Position, // This is the position of the 'func' keyword
 ) error {
-	// TODO: Implement the logic to:
-	// 1. Read the original file content.
-	// 2. Identify the start and end byte offsets of the existing main() function using fileAst and mainFuncPos.
-	//    (This needs careful handling of comments, esp. doc comments of main).
-	// 3. Replace the old main() function block with newMainContent.
-	//    Alternatively, if mainFuncPos is nil (main not found), append newMainContent.
-	// 4. Write the modified content back to filePath or to a new file.
-	//
-	// Consider using go/format.Source to format the generated code before writing.
+	originalContent, err := os.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("reading original file %s: %w", filePath, err)
+	}
 
-	// log.Printf("TODO: Write new main content to %s. Current main position: %v", filePath, mainFuncPos)
-	// log.Println("New main content preview:\n", newMainContent)
+	var newContent []byte
+
+	if mainFuncPos == nil {
+		// Main function not found, append newMainContent to the end of the file.
+		// Ensure there's a newline between existing content and new main, if needed.
+		if len(originalContent) > 0 && originalContent[len(originalContent)-1] != '\n' {
+			originalContent = append(originalContent, '\n')
+		}
+		originalContent = append(originalContent, '\n') // Add an extra newline for separation
+
+		newContent = append(originalContent, []byte(newMainContent)...)
+	} else {
+		// Main function found, replace it.
+		var mainFuncNode *ast.FuncDecl
+		for _, decl := range fileAst.Decls {
+			if fn, ok := decl.(*ast.FuncDecl); ok && fn.Name.Name == "main" {
+				// Check if this is the exact main function we are looking for
+				// by comparing the position of 'func' keyword
+				funcPos := fileSet.Position(fn.Pos())
+				if funcPos.IsValid() && mainFuncPos.IsValid() && funcPos.Offset == mainFuncPos.Offset {
+					mainFuncNode = fn
+					break
+				}
+			}
+		}
+
+		if mainFuncNode == nil {
+			// This case should ideally not happen if mainFuncPos is not nil
+			// and points to a valid 'main' function declaration.
+			// However, as a fallback, append.
+			if len(originalContent) > 0 && originalContent[len(originalContent)-1] != '\n' {
+				originalContent = append(originalContent, '\n')
+			}
+			originalContent = append(originalContent, '\n')
+			newContent = append(originalContent, []byte(newMainContent)...)
+		} else {
+			// Determine start and end of the main function in the original source
+			// Start of the function (including doc comments if any)
+			// We take the position of the 'func' keyword as the definitive start of what we replace.
+			// If there are doc comments, ast.Node.Pos() for FuncDecl usually includes them.
+			// Let's use the provided mainFuncPos as the start of replacement.
+			startOffset := mainFuncPos.Offset
+
+			// End of the function (the closing '}')
+			// mainFuncNode.End() gives the position immediately after the closing brace.
+			endTokenPos := mainFuncNode.Body.Rbrace
+			endOffset := fileSet.Position(endTokenPos).Offset + 1 // +1 to include the brace itself
+
+			if startOffset < 0 || endOffset < startOffset || endOffset > len(originalContent) {
+				return fmt.Errorf("invalid offsets for main function replacement: start=%d, end=%d, file_len=%d", startOffset, endOffset, len(originalContent))
+			}
+
+			var buf bytes.Buffer
+			buf.Write(originalContent[:startOffset])
+			buf.WriteString(newMainContent)
+			// Add a newline after the new main content if it doesn't end with one,
+			// and if there's content following it, or if it's at the EOF.
+			if !strings.HasSuffix(newMainContent, "\n") {
+				buf.WriteString("\n")
+			}
+			buf.Write(originalContent[endOffset:])
+			newContent = buf.Bytes()
+		}
+	}
+
+	// Format the generated code
+	formattedContent, err := format.Source(newContent)
+	if err != nil {
+		// Write the unformatted content for debugging purposes if formatting fails
+		// os.WriteFile(filePath+".unformatted", newContent, 0644)
+		return fmt.Errorf("formatting generated code for %s: %w\nOriginal newContent was:\n%s", filePath, err, string(newContent))
+	}
+
+	// Write the modified content back to filePath
+	err = os.WriteFile(filePath, formattedContent, 0644) // Default permissions
+	if err != nil {
+		return fmt.Errorf("writing modified content to %s: %w", filePath, err)
+	}
+
 	return nil
+}
+
+// Helper function to ensure strings.HasSuffix works as expected with WriteString
+// (it's fine, just for completeness of thought if there were complex scenarios)
+func endsWithNewline(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	return s[len(s)-1] == '\n'
 }

--- a/internal/codegen/writer_test.go
+++ b/internal/codegen/writer_test.go
@@ -1,0 +1,349 @@
+package codegen_test
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/podhmo/goat/internal/codegen"
+	// Assuming normalizeCode is in the same package or adjust import
+)
+
+// createTempFile creates a temporary Go file with the given initial content.
+// It returns the path to the temporary file.
+func createTempFile(t *testing.T, initialContent string) string {
+	t.Helper()
+	tempDir := t.TempDir() // Auto-cleaned up
+	tempFile, err := os.Create(filepath.Join(tempDir, "test_program.go"))
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer tempFile.Close()
+
+	if _, err := tempFile.WriteString(initialContent); err != nil {
+		t.Fatalf("Failed to write initial content to temp file: %v", err)
+	}
+	return tempFile.Name()
+}
+
+// findMainFuncDecl finds the *ast.FuncDecl and its token.Position for the main function.
+// Returns nil if not found.
+func findMainFuncDecl(fset *token.FileSet, fileAst *ast.File) (*ast.FuncDecl, *token.Position) {
+	for _, decl := range fileAst.Decls {
+		if fn, ok := decl.(*ast.FuncDecl); ok && fn.Name.Name == "main" {
+			pos := fset.Position(fn.Pos()) // Get the position of 'func' keyword
+			return fn, &pos
+		}
+	}
+	return nil, nil
+}
+
+func TestWriteMain_ReplaceExistingMain(t *testing.T) {
+	initialContent := `package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, old world!")
+}
+`
+	newMainContent := `
+func main() {
+	fmt.Println("Hello, new world!")
+	fmt.Println("This is the new main.")
+}`
+	expectedContentAfterWrite := `package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, new world!")
+	fmt.Println("This is the new main.")
+}
+`
+	tempFilePath := createTempFile(t, initialContent)
+	fset := token.NewFileSet()
+
+	fileAst, err := parser.ParseFile(fset, tempFilePath, []byte(initialContent), parser.ParseComments)
+	if err != nil {
+		t.Fatalf("Failed to parse initial content: %v", err)
+	}
+
+	_, mainFuncPos := findMainFuncDecl(fset, fileAst)
+	if mainFuncPos == nil {
+		t.Fatal("Test setup error: main function not found in initial content.")
+	}
+
+	err = codegen.WriteMain(tempFilePath, fset, fileAst, newMainContent, mainFuncPos)
+	if err != nil {
+		t.Fatalf("WriteMain failed: %v", err)
+	}
+
+	modifiedContentBytes, err := os.ReadFile(tempFilePath)
+	if err != nil {
+		t.Fatalf("Failed to read modified file: %v", err)
+	}
+
+	if normalizeCode(t, string(modifiedContentBytes)) != normalizeCode(t, expectedContentAfterWrite) {
+		t.Errorf("Content mismatch.\nExpected:\n%s\n\nGot:\n%s",
+			normalizeCode(t, expectedContentAfterWrite),
+			normalizeCode(t, string(modifiedContentBytes)))
+	}
+}
+
+func TestWriteMain_ReplaceMainWithComments(t *testing.T) {
+	initialContent := `package main // Package comment
+
+import "fmt" // Import related comment
+
+// This is a doc comment for old main.
+func main() {
+	// Inner comment
+	fmt.Println("Hello, old world!")
+}
+
+// Another function
+func helper() {}
+`
+	newMainContent := `
+// This is a doc comment for new main.
+func main() {
+	// New inner comment
+	fmt.Println("Hello, new world!")
+}`
+	// The doc comment of the old main is replaced along with the function itself.
+	// Other comments (package, import, other functions) should remain.
+	expectedContentAfterWrite := `package main // Package comment
+
+import "fmt" // Import related comment
+
+// This is a doc comment for new main.
+func main() {
+	// New inner comment
+	fmt.Println("Hello, new world!")
+}
+
+// Another function
+func helper() {}
+`
+	tempFilePath := createTempFile(t, initialContent)
+	fset := token.NewFileSet()
+
+	fileAst, err := parser.ParseFile(fset, tempFilePath, []byte(initialContent), parser.ParseComments)
+	if err != nil {
+		t.Fatalf("Failed to parse initial content: %v", err)
+	}
+
+	_, mainFuncPos := findMainFuncDecl(fset, fileAst)
+	if mainFuncPos == nil {
+		t.Fatal("Test setup error: main function not found in initial content.")
+	}
+
+	err = codegen.WriteMain(tempFilePath, fset, fileAst, newMainContent, mainFuncPos)
+	if err != nil {
+		t.Fatalf("WriteMain failed: %v", err)
+	}
+
+	modifiedContentBytes, err := os.ReadFile(tempFilePath)
+	if err != nil {
+		t.Fatalf("Failed to read modified file: %v", err)
+	}
+
+	if normalizeCode(t, string(modifiedContentBytes)) != normalizeCode(t, expectedContentAfterWrite) {
+		t.Errorf("Content mismatch.\nExpected:\n%s\n\nGot:\n%s",
+			normalizeCode(t, expectedContentAfterWrite),
+			normalizeCode(t, string(modifiedContentBytes)))
+	}
+}
+
+func TestWriteMain_AppendNewMain(t *testing.T) {
+	initialContent := `package main
+
+import "log"
+
+func someOtherFunc() {
+	log.Println("This file has no main yet.")
+}
+`
+	newMainContent := `
+func main() {
+	log.Println("This is the new main, appended.")
+}`
+	// Expected: initial content, a newline (if not present), then new main content, then formatted.
+	expectedContentAfterWrite := `package main
+
+import "log"
+
+func someOtherFunc() {
+	log.Println("This file has no main yet.")
+}
+
+func main() {
+	log.Println("This is the new main, appended.")
+}
+`
+	tempFilePath := createTempFile(t, initialContent)
+	fset := token.NewFileSet()
+	// Parse the file to get fileAst, even though mainFuncPos will be nil
+	fileAst, err := parser.ParseFile(fset, tempFilePath, []byte(initialContent), parser.ParseComments)
+	if err != nil {
+		t.Fatalf("Failed to parse initial content: %v", err)
+	}
+
+	// mainFuncPos is nil because main is not found
+	err = codegen.WriteMain(tempFilePath, fset, fileAst, newMainContent, nil)
+	if err != nil {
+		t.Fatalf("WriteMain failed: %v", err)
+	}
+
+	modifiedContentBytes, err := os.ReadFile(tempFilePath)
+	if err != nil {
+		t.Fatalf("Failed to read modified file: %v", err)
+	}
+	
+	normalizedModified := normalizeCode(t, string(modifiedContentBytes))
+	normalizedExpected := normalizeCode(t, expectedContentAfterWrite)
+
+	if normalizedModified != normalizedExpected {
+		fmt.Println("GOT:\n", string(modifiedContentBytes)) // print raw for easier diff
+		fmt.Println("EXPECTED:\n", expectedContentAfterWrite)
+		t.Errorf("Content mismatch.\nExpected (normalized):\n%s\n\nGot (normalized):\n%s",
+			normalizedExpected,
+			normalizedModified)
+	}
+}
+
+
+func TestWriteMain_FileWithOtherDeclarations(t *testing.T) {
+	initialContent := `package main
+
+import "fmt"
+
+var GlobalVar = "initial value"
+
+const MyConstant = 123
+
+func utilityFunc() {
+	fmt.Println("This is a utility function.")
+}
+
+type MyStruct struct {
+	Field int
+}
+
+func main() {
+	fmt.Println("Old main referring to", GlobalVar, MyConstant)
+	utilityFunc()
+}
+
+func anotherUtility() {
+	fmt.Println("Another utility.")
+}
+`
+	newMainContent := `
+func main() {
+	fmt.Println("New main logic here.")
+	fmt.Println(GlobalVar, MyConstant) // It can still refer to globals
+}`
+	expectedContentAfterWrite := `package main
+
+import "fmt"
+
+var GlobalVar = "initial value"
+
+const MyConstant = 123
+
+func utilityFunc() {
+	fmt.Println("This is a utility function.")
+}
+
+type MyStruct struct {
+	Field int
+}
+
+func main() {
+	fmt.Println("New main logic here.")
+	fmt.Println(GlobalVar, MyConstant) // It can still refer to globals
+}
+
+func anotherUtility() {
+	fmt.Println("Another utility.")
+}
+`
+	tempFilePath := createTempFile(t, initialContent)
+	fset := token.NewFileSet()
+
+	fileAst, err := parser.ParseFile(fset, tempFilePath, []byte(initialContent), parser.ParseComments)
+	if err != nil {
+		t.Fatalf("Failed to parse initial content: %v", err)
+	}
+
+	_, mainFuncPos := findMainFuncDecl(fset, fileAst)
+	if mainFuncPos == nil {
+		t.Fatal("Test setup error: main function not found in initial content.")
+	}
+
+	err = codegen.WriteMain(tempFilePath, fset, fileAst, newMainContent, mainFuncPos)
+	if err != nil {
+		t.Fatalf("WriteMain failed: %v", err)
+	}
+
+	modifiedContentBytes, err := os.ReadFile(tempFilePath)
+	if err != nil {
+		t.Fatalf("Failed to read modified file: %v", err)
+	}
+
+	if normalizeCode(t, string(modifiedContentBytes)) != normalizeCode(t, expectedContentAfterWrite) {
+		t.Errorf("Content mismatch.\nExpected:\n%s\n\nGot:\n%s",
+			normalizeCode(t, expectedContentAfterWrite),
+			normalizeCode(t, string(modifiedContentBytes)))
+	}
+}
+
+func TestWriteMain_EmptyFileInput(t *testing.T) {
+	initialContent := ""
+	newMainContent := `package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello from a new file!")
+}`
+	// Expected is just the new main content, formatted.
+	expectedContentAfterWrite := newMainContent
+
+	tempFilePath := createTempFile(t, initialContent)
+	fset := token.NewFileSet()
+
+	// Parsing an empty string might result in a non-nil fileAst with no decls.
+	fileAst, err := parser.ParseFile(fset, tempFilePath, nil, parser.ParseComments) // Pass nil for []byte for empty
+	if err != nil {
+		t.Fatalf("Failed to parse initial (empty) content: %v", err)
+	}
+
+	// mainFuncPos is nil as the file is empty
+	err = codegen.WriteMain(tempFilePath, fset, fileAst, newMainContent, nil)
+	if err != nil {
+		t.Fatalf("WriteMain failed: %v", err)
+	}
+
+	modifiedContentBytes, err := os.ReadFile(tempFilePath)
+	if err != nil {
+		t.Fatalf("Failed to read modified file: %v", err)
+	}
+	
+	normalizedModified := normalizeCode(t, string(modifiedContentBytes))
+	normalizedExpected := normalizeCode(t, expectedContentAfterWrite)
+
+
+	if normalizedModified != normalizedExpected {
+		t.Errorf("Content mismatch.\nExpected:\n%s\n\nGot:\n%s",
+			normalizedExpected,
+			normalizedModified)
+	}
+}


### PR DESCRIPTION
refactor(codegen): Remove Options struct generation from GenerateMain

Refactor `internal/codegen/main_generator.go` to eliminate the generation of an `Options` struct. Command-line flags are now parsed into individual local variables within the generated `main` function.

Key changes:

- `internal/codegen/main_generator.go`:
    - Removed the template logic that generated the `type Options struct {...}`.
    - Flags defined in `CommandMetadata.Options` are now declared as individual local variables (e.g., `var ConfigFlag string`).
    - `flag.StringVar/IntVar/BoolVar` calls now use pointers to these individual variables.
    - Environment variable lookups and assignments are mapped to these individual variables.
    - Required flag checks and enum validations operate on these variables.
    - The generated code now calls the `RunFunc` with these individual flag variables as direct arguments, assuming the order in `CommandMetadata.Options` matches the function's parameter order. A new template helper `JoinFlagVars` facilitates this.
    - Conditional import of `strconv` is handled directly in the template to avoid duplication if already included by the user.
    - Improved logic for environment variable precedence over default flag values.
    - String default values in `flag.StringVar` are now correctly quoted using `printf "%q"`.

- `internal/codegen/main_generator_test.go`:
    - Unit tests have been comprehensively updated to align with the removal of the `Options` struct.
    - Assertions now verify the declaration of individual flag variables.
    - Tests check that `RunFunc` is called with individual variables as arguments.
    - Expected code snippets in all relevant test cases have been modified.
    - Added `assertCodeNotContains` helper and improved `assertCodeContains`.
    - Added a specific test case for string flag default values containing quotes.

This change simplifies the generated code for cases where an intermediate options struct is not desired and provides more direct control over flag variables.

Output:
I've refactored `internal/codegen/main_generator.go` to eliminate the generation of an `Options` struct. Command-line flags are now parsed into individual local variables within the generated `main` function.

Here are the key changes:

- In `internal/codegen/main_generator.go`:
    - I removed the template logic that generated the `type Options struct {...}`.
    - Flags defined in `CommandMetadata.Options` are now declared as individual local variables (e.g., `var ConfigFlag string`).
    - `flag.StringVar/IntVar/BoolVar` calls now use pointers to these individual variables.
    - Environment variable lookups and assignments are mapped to these individual variables.
    - Required flag checks and enum validations operate on these variables.
    - The generated code now calls the `RunFunc` with these individual flag variables as direct arguments, assuming the order in `CommandMetadata.Options` matches the function's parameter order. A new template helper `JoinFlagVars` facilitates this.
    - Conditional import of `strconv` is handled directly in the template to avoid duplication if already included by you.
    - I improved the logic for environment variable precedence over default flag values.
    - String default values in `flag.StringVar` are now correctly quoted using `printf "%q"`.

- In `internal/codegen/main_generator_test.go`:
    - I've comprehensively updated the unit tests to align with the removal of the `Options` struct.
    - Assertions now verify the declaration of individual flag variables.
    - Tests check that `RunFunc` is called with individual variables as arguments.
    - Expected code snippets in all relevant test cases have been modified.
    - I added an `assertCodeNotContains` helper and improved `assertCodeContains`.
    - I also added a specific test case for string flag default values containing quotes.

This change simplifies the generated code for cases where an intermediate options struct is not desired and provides more direct control over flag variables.