### PR TITLE
feat: Support embedded structs in options analysis

### DIFF
--- a/internal/analyzer/options_analyzer_test.go
+++ b/internal/analyzer/options_analyzer_test.go
@@ -124,3 +124,93 @@ func TestAnalyzeOptions_StructNotFound(t *testing.T) {
 		t.Errorf("Unexpected error message: %v", err)
 	}
 }
+
+func TestAnalyzeOptions_WithEmbeddedStructs(t *testing.T) {
+	// Scenario 1 Content
+	content1 := `
+package main
+
+type EmbeddedConfig struct {
+	// Description for EmbeddedString.
+	EmbeddedString string %s
+	// Description for EmbeddedInt, it's optional.
+	EmbeddedInt *int %s
+}
+
+type ParentConfig struct {
+	// Description for ParentField.
+	ParentField bool %s
+	EmbeddedConfig
+	AnotherField string
+}
+`
+	formattedContent1 := fmt.Sprintf(content1, "`env:\"EMBEDDED_STRING\"`", "`env:\"EMBEDDED_INT\"`", "`env:\"PARENT_FIELD\"`")
+	fileAst1 := parseTestFile(t, formattedContent1)
+
+	expectedOptions1 := []*metadata.OptionMetadata{
+		{Name: "ParentField", CliName: "parent-field", TypeName: "bool", HelpText: "Description for ParentField.", IsRequired: true, EnvVar: "PARENT_FIELD"},
+		{Name: "EmbeddedString", CliName: "embedded-string", TypeName: "string", HelpText: "Description for EmbeddedString.", IsRequired: true, EnvVar: "EMBEDDED_STRING"},
+		{Name: "EmbeddedInt", CliName: "embedded-int", TypeName: "*int", HelpText: "Description for EmbeddedInt, it's optional.", IsPointer: true, IsRequired: false, EnvVar: "EMBEDDED_INT"},
+		{Name: "AnotherField", CliName: "another-field", TypeName: "string", HelpText: "", IsRequired: true, EnvVar: ""},
+	}
+
+	options1, structName1, err1 := AnalyzeOptions(fileAst1, "ParentConfig", "main")
+	if err1 != nil {
+		t.Fatalf("Scenario 1: AnalyzeOptions failed: %v", err1)
+	}
+	if structName1 != "ParentConfig" {
+		t.Errorf("Scenario 1: Expected struct name 'ParentConfig', got '%s'", structName1)
+	}
+	if len(options1) != len(expectedOptions1) {
+		t.Fatalf("Scenario 1: Expected %d options, got %d. Options: %+v", len(expectedOptions1), len(options1), options1)
+	}
+	for i, opt := range options1 {
+		expectedOpt := expectedOptions1[i]
+		if opt.Name != expectedOpt.Name || opt.CliName != expectedOpt.CliName ||
+			opt.TypeName != expectedOpt.TypeName || strings.TrimSpace(opt.HelpText) != strings.TrimSpace(expectedOpt.HelpText) ||
+			opt.IsPointer != expectedOpt.IsPointer || opt.IsRequired != expectedOpt.IsRequired ||
+			opt.EnvVar != expectedOpt.EnvVar {
+			t.Errorf("Scenario 1, Option %d Mismatch:\nExpected: %+v\nGot:      %+v", i, expectedOpt, opt)
+		}
+	}
+
+	// Scenario 2 Content
+	content2 := `
+package main
+
+type EmbeddedPointerConfig struct {
+    // Desc for PtrEmbeddedField
+    PtrEmbeddedField float64 %s
+}
+
+type ParentWithPointerEmbedded struct {
+    ParentOwn string
+    *EmbeddedPointerConfig
+}
+`
+	formattedContent2 := fmt.Sprintf(content2, "`env:\"PTR_EMBEDDED_FLOAT\"`")
+	fileAst2 := parseTestFile(t, formattedContent2)
+	expectedOptions2 := []*metadata.OptionMetadata{
+		{Name: "ParentOwn", CliName: "parent-own", TypeName: "string", HelpText: "", IsRequired: true, EnvVar: ""},
+		{Name: "PtrEmbeddedField", CliName: "ptr-embedded-field", TypeName: "float64", HelpText: "Desc for PtrEmbeddedField", IsRequired: true, EnvVar: "PTR_EMBEDDED_FLOAT"},
+	}
+	options2, structName2, err2 := AnalyzeOptions(fileAst2, "ParentWithPointerEmbedded", "main")
+	if err2 != nil {
+		t.Fatalf("Scenario 2: AnalyzeOptions failed: %v", err2)
+	}
+	if structName2 != "ParentWithPointerEmbedded" {
+		t.Errorf("Scenario 2: Expected struct name 'ParentWithPointerEmbedded', got '%s'", structName2)
+	}
+	if len(options2) != len(expectedOptions2) {
+		t.Fatalf("Scenario 2: Expected %d options, got %d. Options: %+v", len(expectedOptions2), len(options2), options2)
+	}
+	for i, opt := range options2 {
+		expectedOpt := expectedOptions2[i]
+		if opt.Name != expectedOpt.Name || opt.CliName != expectedOpt.CliName ||
+			opt.TypeName != expectedOpt.TypeName || strings.TrimSpace(opt.HelpText) != strings.TrimSpace(expectedOpt.HelpText) ||
+			opt.IsPointer != expectedOpt.IsPointer || opt.IsRequired != expectedOpt.IsRequired ||
+			opt.EnvVar != expectedOpt.EnvVar {
+			t.Errorf("Scenario 2, Option %d Mismatch:\nExpected: %+v\nGot:      %+v", i, expectedOpt, opt)
+		}
+	}
+}


### PR DESCRIPTION
I modified the `AnalyzeOptions` function in `internal/analyzer/options_analyzer.go` to recursively analyze fields from embedded structs. This allows options to be defined in separate, reusable struct types and then embedded into a primary options struct.

Key changes:
- When an embedded struct field is encountered (a field with no name), `AnalyzeOptions` now recursively calls itself to analyze the fields of the embedded type.
- I correctly handled type name resolution for embedded structs, including those embedded via pointers (e.g., `*MyEmbeddedConfig`). I fixed a bug where the leading '*' was not stripped from the type name before AST lookup.
- I added `TestAnalyzeOptions_WithEmbeddedStructs` in `internal/analyzer/options_analyzer_test.go` with scenarios for both direct embedding and pointer-to-struct embedding. These tests verify the correct extraction of field metadata (name, type, help text, tags) from both parent and embedded structs.

All tests pass, ensuring the new functionality is working as expected and existing functionality remains unaffected.