### PR TITLE
Refactor: Simplify import and formatting logic in codegen

### DIFF
--- a/cmd/goat/main.go
+++ b/cmd/goat/main.go
@@ -158,7 +158,9 @@ func runGoat(cfg *config.Config) error {
 	helpMsg := help.GenerateHelp(cmdMetadata)
 
 	// 5. TODO: Generate new main.go content (Future Step)
-	newMainContent, err := codegen.GenerateMain(cmdMetadata, helpMsg)
+	// For 'emit', we only want the function body, not a full file,
+	// as it will be inserted into an existing file.
+	newMainContent, err := codegen.GenerateMain(cmdMetadata, helpMsg, false /* generateFullFile */)
 	if err != nil {
 		return fmt.Errorf("failed to generate new main.go content: %w", err)
 	}

--- a/internal/codegen/main_generator.go
+++ b/internal/codegen/main_generator.go
@@ -3,7 +3,6 @@ package codegen
 import (
 	"bytes"
 	"fmt"
-	"go/format"
 	"strings"
 	"text/template"
 
@@ -12,7 +11,9 @@ import (
 
 // GenerateMain creates the Go code string for the new main() function
 // based on the extracted command metadata.
-func GenerateMain(cmdMeta *metadata.CommandMetadata, helpText string) (string, error) {
+// If generateFullFile is true, it returns a complete Go file content including package and imports.
+// Otherwise, it returns only the main function body.
+func GenerateMain(cmdMeta *metadata.CommandMetadata, helpText string, generateFullFile bool) (string, error) {
 	// Helper function for the template to join option names for the function call
 	templateFuncs := template.FuncMap{
 		"Title": strings.Title,
@@ -149,40 +150,24 @@ func main() {
 }
 `))
 
-	needsStrconv := false
-	for _, opt := range cmdMeta.Options {
-		if opt.EnvVar != "" && (opt.TypeName == "int" || opt.TypeName == "bool") {
-			needsStrconv = true
-			break
-		}
-	}
 	// RunFuncInfo no longer provides Imports.
-	// The template will only include "strconv" if needsStrconv is true,
-	// and other necessary direct imports like "flag", "fmt", "log", "os".
+	// Necessary direct imports like "flag", "fmt", "log", "os", "strconv", "strings"
+	// will be added explicitly to the generated code.
 	// User-specific imports from the original run command's package must be handled
 	// by the user ensuring the run command's package itself is importable and correct.
-	var finalImports []string // Will be empty or contain only "strconv" if not via NeedsStrconv
-	if needsStrconv {
-		// This will be handled by the {{if .NeedsStrconv}} "strconv" {{end}} block in the template.
-		// We set NeedsStrconv to true, and the template handles the import.
-		// No need to add to finalImports directly here if the template handles "strconv" specifically.
-	}
 
 	data := struct {
 		RunFuncName    string
 		RunFuncPackage string
-		Options        []*metadata.OptionMetadata // Changed from []metadata.Option
+		Options        []*metadata.OptionMetadata
 		HasOptions     bool
-		Imports        []string // This will be empty, user imports not carried over
-		NeedsStrconv   bool
-		HelpText       string
+		// Imports field is removed as it was unused and imports are now static
+		HelpText string
 	}{
 		RunFuncName:    cmdMeta.RunFunc.Name,
 		RunFuncPackage: cmdMeta.RunFunc.PackageName,
-		Options:        cmdMeta.Options, // This is already []*metadata.OptionMetadata from CommandMetadata
+		Options:        cmdMeta.Options,
 		HasOptions:     len(cmdMeta.Options) > 0,
-		Imports:        finalImports, // Pass empty slice, template handles strconv
-		NeedsStrconv:   needsStrconv,
 		HelpText:       helpText,
 	}
 
@@ -191,11 +176,20 @@ func main() {
 		return "", fmt.Errorf("executing template: %w", err)
 	}
 
-	formattedCode, err := format.Source(generatedCode.Bytes())
-	if err != nil {
-		// For debugging, return the unformatted code to see the issue
-		return "", fmt.Errorf("formatting generated code: %w\nRaw generated code:\n%s", err, generatedCode.String())
+	if generateFullFile {
+		// Construct the full Go source file content
+		var sb strings.Builder
+		sb.WriteString("package main\n\n")
+		sb.WriteString("import (\n")
+		sb.WriteString("\t\"flag\"\n")
+		sb.WriteString("\t\"fmt\"\n")
+		sb.WriteString("\t\"log\"\n")
+		sb.WriteString("\t\"os\"\n")
+		sb.WriteString("\t\"strconv\"\n")
+		sb.WriteString("\t\"strings\"\n") // strings might be used by generated code for e.g. enum validation
+		sb.WriteString(")\n\n")
+		sb.WriteString(generatedCode.String())
+		return sb.String(), nil
 	}
-
-	return string(formattedCode), nil
+	return generatedCode.String(), nil
 }

--- a/internal/codegen/main_generator_test.go
+++ b/internal/codegen/main_generator_test.go
@@ -83,7 +83,7 @@ func TestGenerateMain_BasicCase(t *testing.T) {
 		Options: []*metadata.OptionMetadata{}, // Changed to []*OptionMetadata
 	}
 
-	actualCode, err := codegen.GenerateMain(cmdMeta, "")
+	actualCode, err := codegen.GenerateMain(cmdMeta, "", true)
 	if err != nil {
 		t.Fatalf("GenerateMain failed: %v", err)
 	}
@@ -113,7 +113,7 @@ func TestGenerateMain_WithOptions(t *testing.T) {
 		},
 	}
 
-	actualCode, err := codegen.GenerateMain(cmdMeta, "")
+	actualCode, err := codegen.GenerateMain(cmdMeta, "", true)
 	if err != nil {
 		t.Fatalf("GenerateMain failed: %v", err)
 	}
@@ -146,7 +146,7 @@ func TestGenerateMain_RequiredFlags(t *testing.T) {
 		},
 	}
 
-	actualCode, err := codegen.GenerateMain(cmdMeta, "")
+	actualCode, err := codegen.GenerateMain(cmdMeta, "", true)
 	if err != nil {
 		t.Fatalf("GenerateMain failed: %v", err)
 	}
@@ -185,7 +185,7 @@ func TestGenerateMain_EnumValidation(t *testing.T) {
 		},
 	}
 
-	actualCode, err := codegen.GenerateMain(cmdMeta, "")
+	actualCode, err := codegen.GenerateMain(cmdMeta, "", true)
 	if err != nil {
 		t.Fatalf("GenerateMain failed: %v", err)
 	}
@@ -217,7 +217,7 @@ func TestGenerateMain_EnvironmentVariables(t *testing.T) {
 		},
 	}
 
-	actualCode, err := codegen.GenerateMain(cmdMeta, "")
+	actualCode, err := codegen.GenerateMain(cmdMeta, "", true)
 	if err != nil {
 		t.Fatalf("GenerateMain failed: %v", err)
 	}
@@ -264,7 +264,7 @@ func TestGenerateMain_RunFuncInvocation(t *testing.T) {
 	cmdMetaNoOpts := &metadata.CommandMetadata{
 		RunFunc: &metadata.RunFuncInfo{Name: "Execute", PackageName: "action"},
 	}
-	actualCodeNoOpts, err := codegen.GenerateMain(cmdMetaNoOpts, "")
+	actualCodeNoOpts, err := codegen.GenerateMain(cmdMetaNoOpts, "", true)
 	if err != nil {
 		t.Fatalf("GenerateMain (no opts) failed: %v", err)
 	}
@@ -277,7 +277,7 @@ func TestGenerateMain_RunFuncInvocation(t *testing.T) {
 			{Name: "level", CliName: "level", TypeName: "int", HelpText: ""},    // Added CliName, HelpText
 		},
 	}
-	actualCodeWithOptions, err := codegen.GenerateMain(cmdMetaWithOptions, "")
+	actualCodeWithOptions, err := codegen.GenerateMain(cmdMetaWithOptions, "", true)
 	if err != nil {
 		t.Fatalf("GenerateMain (with opts) failed: %v", err)
 	}
@@ -288,7 +288,7 @@ func TestGenerateMain_ErrorHandling(t *testing.T) {
 	cmdMeta := &metadata.CommandMetadata{
 		RunFunc: &metadata.RunFuncInfo{Name: "DefaultRun", PackageName: "pkg"},
 	}
-	actualCode, err := codegen.GenerateMain(cmdMeta, "")
+	actualCode, err := codegen.GenerateMain(cmdMeta, "", true)
 	if err != nil {
 		t.Fatalf("GenerateMain failed: %v", err)
 	}
@@ -311,7 +311,7 @@ func TestGenerateMain_Imports(t *testing.T) {
 		},
 	}
 
-	actualCodeNoStrconv, err := codegen.GenerateMain(cmdMetaNoStrconv, "")
+	actualCodeNoStrconv, err := codegen.GenerateMain(cmdMetaNoStrconv, "", true)
 	if err != nil {
 		t.Fatalf("GenerateMain failed: %v", err)
 	}
@@ -330,7 +330,7 @@ func TestGenerateMain_Imports(t *testing.T) {
 			{Name: "port", CliName: "port", TypeName: "int", EnvVar: "APP_PORT", HelpText: "app port"},
 		},
 	}
-	actualCodeWithStrconv, err := codegen.GenerateMain(cmdMetaWithStrconv, "")
+	actualCodeWithStrconv, err := codegen.GenerateMain(cmdMetaWithStrconv, "", true)
 	if err != nil {
 		t.Fatalf("GenerateMain failed: %v", err)
 	}
@@ -348,7 +348,7 @@ func TestGenerateMain_RequiredIntWithEnvVar(t *testing.T) {
 		},
 	}
 
-	actualCode, err := codegen.GenerateMain(cmdMeta, "")
+	actualCode, err := codegen.GenerateMain(cmdMeta, "", true)
 	if err != nil {
 		t.Fatalf("GenerateMain failed: %v", err)
 	}
@@ -384,7 +384,7 @@ func TestGenerateMain_StringFlagWithQuotesInDefault(t *testing.T) {
 			{Name: "greeting", CliName: "greeting", TypeName: "string", HelpText: "A greeting message", DefaultValue: `hello "world"`},
 		},
 	}
-	actualCode, err := codegen.GenerateMain(cmdMeta, "")
+	actualCode, err := codegen.GenerateMain(cmdMeta, "", true)
 	if err != nil {
 		t.Fatalf("GenerateMain failed: %v", err)
 	}
@@ -405,7 +405,7 @@ func TestGenerateMain_WithHelpText(t *testing.T) {
 	}
 	helpText := "This is my custom help message.\nUsage: mytool -input <file>"
 
-	actualCode, err := codegen.GenerateMain(cmdMeta, helpText)
+	actualCode, err := codegen.GenerateMain(cmdMeta, helpText, true)
 	if err != nil {
 		t.Fatalf("GenerateMain with help text failed: %v", err)
 	}
@@ -437,7 +437,7 @@ func TestGenerateMain_WithEmptyHelpText(t *testing.T) {
 		Options: []*metadata.OptionMetadata{},
 	}
 
-	actualCode, err := codegen.GenerateMain(cmdMeta, "")
+	actualCode, err := codegen.GenerateMain(cmdMeta, "", true)
 	if err != nil {
 		t.Fatalf("GenerateMain with empty help text failed: %v", err)
 	}

--- a/internal/help/generator.go
+++ b/internal/help/generator.go
@@ -21,7 +21,7 @@ func GenerateHelp(cmdMeta *metadata.CommandMetadata) string {
 
 func generateHelp(w io.Writer, cmdMeta *metadata.CommandMetadata) {
 	fmt.Fprintf(w, "%s - %s\n\n", cmdMeta.Name, strings.ReplaceAll(cmdMeta.Description, "\n", "\n         "))
-	fmt.Fprintf(w, "Usage:\n  %s [flags] %s\n\n", cmdMeta.Name, "") // CommandArgsPlaceholder is empty for now
+	fmt.Fprintf(w, "Usage:\n  %s [flags]\n\n", cmdMeta.Name) // Removed CommandArgsPlaceholder and trailing space
 	fmt.Fprintln(w, "Flags:")
 
 	// Find max length of option names for alignment (include -h, --help)

--- a/internal/help/generator_test.go
+++ b/internal/help/generator_test.go
@@ -56,7 +56,7 @@ func TestGenerateHelp_Basic(t *testing.T) {
          Does amazing things.
 
 Usage:
-  mytool [flags] 
+  mytool [flags]
 
 Flags:
   --username  string The username for login. (required) (env: APP_USER)


### PR DESCRIPTION
This pull request refactors the `GenerateMain` function and its usage across the codebase to support generating either a full Go source file or just the function body. It also simplifies imports handling and removes unused code. Additionally, it updates related tests to accommodate these changes.

### Refactoring of `GenerateMain` function:

* [`internal/codegen/main_generator.go`](diffhunk://#diff-868c6d35af8fd2c62e13f8acf0c9510fa5225da240702c6d3b379dd1b5666057L15-R16): Modified `GenerateMain` to accept a `generateFullFile` flag, enabling generation of either a full Go file or just the function body. Removed dynamic imports logic and unused `Imports` and `NeedsStrconv` fields. [[1]](diffhunk://#diff-868c6d35af8fd2c62e13f8acf0c9510fa5225da240702c6d3b379dd1b5666057L15-R16) [[2]](diffhunk://#diff-868c6d35af8fd2c62e13f8acf0c9510fa5225da240702c6d3b379dd1b5666057L152-L185) [[3]](diffhunk://#diff-868c6d35af8fd2c62e13f8acf0c9510fa5225da240702c6d3b379dd1b5666057L194-R194)

### Updates to `cmd/goat/main.go`:

* [`cmd/goat/main.go`](diffhunk://#diff-f73f4bf5b0f8ab54dbaee0089300026ed2ed78d4634b0d5842a9da9bad5ad261L161-R163): Updated the call to `GenerateMain` to pass the new `generateFullFile` flag as `false`, ensuring only the function body is generated for insertion into an existing file.

### Simplification of imports:

* [`internal/codegen/main_generator.go`](diffhunk://#diff-868c6d35af8fd2c62e13f8acf0c9510fa5225da240702c6d3b379dd1b5666057L6): Removed the `go/format` import as formatting is no longer performed in `GenerateMain`. Static imports are now explicitly added for full file generation. [[1]](diffhunk://#diff-868c6d35af8fd2c62e13f8acf0c9510fa5225da240702c6d3b379dd1b5666057L6) [[2]](diffhunk://#diff-868c6d35af8fd2c62e13f8acf0c9510fa5225da240702c6d3b379dd1b5666057L194-R194)

### Test updates:

* [`internal/codegen/main_generator_test.go`](diffhunk://#diff-dab3748b8d859c73ae6267187196d3b1499f249fb15b7b1f0e7e237aa3c65cd1L86-R86): Updated all test cases to include the `generateFullFile` flag when calling `GenerateMain`. This ensures tests cover the new functionality of generating full files. [[1]](diffhunk://#diff-dab3748b8d859c73ae6267187196d3b1499f249fb15b7b1f0e7e237aa3c65cd1L86-R86) [[2]](diffhunk://#diff-dab3748b8d859c73ae6267187196d3b1499f249fb15b7b1f0e7e237aa3c65cd1L116-R116) [[3]](diffhunk://#diff-dab3748b8d859c73ae6267187196d3b1499f249fb15b7b1f0e7e237aa3c65cd1L149-R149) [[4]](diffhunk://#diff-dab3748b8d859c73ae6267187196d3b1499f249fb15b7b1f0e7e237aa3c65cd1L188-R188) [[5]](diffhunk://#diff-dab3748b8d859c73ae6267187196d3b1499f249fb15b7b1f0e7e237aa3c65cd1L220-R220) [[6]](diffhunk://#diff-dab3748b8d859c73ae6267187196d3b1499f249fb15b7b1f0e7e237aa3c65cd1L267-R267) [[7]](diffhunk://#diff-dab3748b8d859c73ae6267187196d3b1499f249fb15b7b1f0e7e237aa3c65cd1L280-R280) [[8]](diffhunk://#diff-dab3748b8d859c73ae6267187196d3b1499f249fb15b7b1f0e7e237aa3c65cd1L291-R291) [[9]](diffhunk://#diff-dab3748b8d859c73ae6267187196d3b1499f249fb15b7b1f0e7e237aa3c65cd1L314-R314) [[10]](diffhunk://#diff-dab3748b8d859c73ae6267187196d3b1499f249fb15b7b1f0e7e237aa3c65cd1L333-R333) [[11]](diffhunk://#diff-dab3748b8d859c73ae6267187196d3b1499f249fb15b7b1f0e7e237aa3c65cd1L351-R351) [[12]](diffhunk://#diff-dab3748b8d859c73ae6267187196d3b1499f249fb15b7b1f0e7e237aa3c65cd1L387-R387) [[13]](diffhunk://#diff-dab3748b8d859c73ae6267187196d3b1499f249fb15b7b1f0e7e237aa3c65cd1L408-R408) [[14]](diffhunk://#diff-dab3748b8d859c73ae6267187196d3b1499f249fb15b7b1f0e7e237aa3c65cd1L440-R440)

### Minor improvement to help text generation:

* [`internal/help/generator.go`](diffhunk://#diff-e99dc207109aa57c52edc8e0fc69f4475774f0f1d41e3ffd3660da02297d58d5L24-R24): Simplified the `Usage` section of the generated help text by removing the `CommandArgsPlaceholder` and trailing space.