### PR TITLE
make test task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,7 @@ check:
 format:
 	goimports -w $(shell find . -name '*.go' -not -path './vendor/*' -not -path './.git/*')
 .PHONY: format
+
+test:
+	go test ./...
+.PHONY: test


### PR DESCRIPTION
1.  **Add `test` target to Makefile**: I'll introduce a new `test` target to the Makefile. This will allow you to run all tests in the project by simply executing `make test`. The command `go test ./...` will be used for this purpose.