### PR TITLE
Refactor: Move Config struct from internal/config to cmd/goat

### DIFF
--- a/cmd/goat/main.go
+++ b/cmd/goat/main.go
@@ -14,12 +14,19 @@ import (
 
 	"github.com/podhmo/goat/internal/analyzer" // Ensure full path
 	"github.com/podhmo/goat/internal/codegen"
-	"github.com/podhmo/goat/internal/config"
 	"github.com/podhmo/goat/internal/help"
 	"github.com/podhmo/goat/internal/interpreter"
 	"github.com/podhmo/goat/internal/loader" // Ensure full path
 	"github.com/podhmo/goat/internal/metadata"
 )
+
+// Config holds the configuration for the goat tool itself,
+// typically derived from its command-line arguments.
+type Config struct {
+	RunFuncName            string // Name of the target 'run' function (e.g., "run")
+	OptionsInitializerName string // Name of the options initializer function (e.g., "NewOptions")
+	TargetFile             string // Path to the target Go file to be processed
+}
 
 func main() {
 	if len(os.Args) < 2 {
@@ -55,7 +62,7 @@ func main() {
 		}
 		targetFilename := emitCmd.Arg(0)
 
-		cfg := &config.Config{
+		cfg := &Config{
 			RunFuncName:            runFuncName,
 			OptionsInitializerName: optionsInitializerName,
 			TargetFile:             targetFilename,
@@ -87,7 +94,7 @@ func main() {
 		}
 		targetFilename := helpMessageCmd.Arg(0)
 
-		cfg := &config.Config{
+		cfg := &Config{
 			RunFuncName:            runFuncName,
 			OptionsInitializerName: optionsInitializerName,
 			TargetFile:             targetFilename,
@@ -125,7 +132,7 @@ func main() {
 		}
 		targetFilename := scanCmd.Arg(0)
 
-		cfg := &config.Config{
+		cfg := &Config{
 			RunFuncName:            runFuncName,
 			OptionsInitializerName: optionsInitializerName,
 			TargetFile:             targetFilename,
@@ -152,7 +159,7 @@ func main() {
 	}
 }
 
-func runGoat(cfg *config.Config) error {
+func runGoat(cfg *Config) error {
 	fset := token.NewFileSet()
 	cmdMetadata, fileAST, err := scanMain(fset, cfg)
 	if err != nil {
@@ -179,7 +186,7 @@ func runGoat(cfg *config.Config) error {
 	return nil
 }
 
-func scanMain(fset *token.FileSet, cfg *config.Config) (*metadata.CommandMetadata, *ast.File, error) {
+func scanMain(fset *token.FileSet, cfg *Config) (*metadata.CommandMetadata, *ast.File, error) {
 	slog.Info("Goat: Analyzing file", "targetFile", cfg.TargetFile, "runFunc", cfg.RunFuncName, "optionsInitializer", cfg.OptionsInitializerName)
 
 	targetFileAst, err := loader.LoadFile(fset, cfg.TargetFile)

--- a/cmd/goat/main_test.go
+++ b/cmd/goat/main_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"go/parser" // Added for TestEmitSubcommand
 
-	"github.com/podhmo/goat/internal/config"
 	"github.com/podhmo/goat/internal/help"
 	"github.com/podhmo/goat/internal/metadata"
 )
@@ -124,7 +123,7 @@ func TestHelpGenerateHelpOutput(t *testing.T) {
 		t.Fatalf("Failed to write temp file: %v", err)
 	}
 
-	cfg := &config.Config{
+	cfg := &Config{
 		RunFuncName:            "Run",
 		OptionsInitializerName: "NewOptions",
 		TargetFile:             tmpFile,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,9 +1,0 @@
-package config
-
-// Config holds the configuration for the goat tool itself,
-// typically derived from its command-line arguments.
-type Config struct {
-	RunFuncName            string // Name of the target 'run' function (e.g., "run")
-	OptionsInitializerName string // Name of the options initializer function (e.g., "NewOptions")
-	TargetFile             string // Path to the target Go file to be processed
-}


### PR DESCRIPTION
The Config struct, previously in internal/config/config.go, was only used by cmd/goat/main.go.

I moved the Config struct definition directly into cmd/goat/main.go and removed the now-empty internal/config package.

This change simplifies the project structure by colocating the configuration definition with its sole user. Tests in cmd/goat/main_test.go were updated accordingly. All tests pass.