### PR TITLE
Refactor: Rename Config to Options in cmd/goat

### DIFF
--- a/cmd/goat/main_test.go
+++ b/cmd/goat/main_test.go
@@ -123,14 +123,14 @@ func TestHelpGenerateHelpOutput(t *testing.T) {
 		t.Fatalf("Failed to write temp file: %v", err)
 	}
 
-	cfg := &Config{
+	opts := &Options{
 		RunFuncName:            "Run",
 		OptionsInitializerName: "NewOptions",
 		TargetFile:             tmpFile,
 	}
 
 	fset := token.NewFileSet()
-	cmdMetadata, _, err := scanMain(fset, cfg)
+	cmdMetadata, _, err := scanMain(fset, opts)
 	if err != nil {
 		t.Fatalf("scanMain() error = %v", err)
 	}


### PR DESCRIPTION
I've renamed the Config struct to Options in cmd/goat/main.go and cmd/goat/main_test.go. This includes updating the struct definition, comments, variable names (cfg to opts), and all related references.

All tests continue to pass after this refactoring.