### PR TITLE
Refactor main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 check:
-#	go run ./cmd/goat/ examples/fullset/main.go
-	go run ./cmd/goat/ examples/hello/main.go
+#	go run ./cmd/goat/ help-message examples/fullset/main.go
+	go run ./cmd/goat/ help-message examples/hello/main.go
 .PHONY: check
 
 # format the code

--- a/examples/hello/main.go
+++ b/examples/hello/main.go
@@ -5,29 +5,49 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"log/slog"
 	"os"
 )
-
-func main() {
-	// TODO: generate this main function using `goat` tool
-
-	var options options
-	flag.BoolVar(&options.Version, "version", false, "Print version information")
-	flag.BoolVar(&options.Help, "help", false, "Show help message")
-	flag.StringVar(&options.ConfigFile, "config", "", "Path to the configuration file")
-
-	flag.Parse()
-
-	if err := run(options); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-		os.Exit(1)
-	}
-}
 
 type options struct {
 	Version    bool   // Print version information
 	Help       bool   // Show help message
 	ConfigFile string // Path to the configuration file
+}
+
+func main() { /* generated code will replace this */
+	var options = &options{}
+
+	flag.BoolVar(&options.Version, "Version", false, "Print version information")
+	flag.BoolVar(&options.Help, "Help", false, "Show help message")
+	flag.StringVar(&options.ConfigFile, "ConfigFile", "", "Path to the configuration file")
+
+	flag.Usage = func() {
+		fmt.Fprint(os.Stderr, `main - 
+
+Usage:
+  main [flags]
+
+Flags:
+  --version     bool Print version information (required)
+  --help        bool Show help message (required)
+  --config-file string Path to the configuration file (required)
+
+  -h, --help   Show this help message and exit
+`)
+	}
+
+	flag.Parse()
+
+	if options.ConfigFile == "" {
+		slog.Error("Missing required flag", "flag", "ConfigFile")
+		os.Exit(1)
+	}
+
+	if err := run(*options); err != nil {
+		slog.Error("Runtime error", "error", err)
+		os.Exit(1)
+	}
 }
 
 func run(options options) error {


### PR DESCRIPTION
This pull request primarily refines the `goat` tool's functionality, improves the generated code in the `examples/hello/main.go` file, and cleans up unused or outdated logic in the `cmd/goat/main.go` file. The changes enhance code clarity, improve error handling, and ensure better usability of the tool.

### Improvements to the `goat` tool:

* **Updated `Makefile` commands to include `help-message` functionality**: The `check` target now runs examples with the `help-message` flag, reflecting the tool's enhanced capability to generate help messages. (`Makefile`, [MakefileL3-R4](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L3-R4))
* **Refined imports in `cmd/goat/main.go`**: Removed redundant comments and ensured imports are cleanly formatted. (`cmd/goat/main.go`, [cmd/goat/main.goL8-R19](diffhunk://#diff-f73f4bf5b0f8ab54dbaee0089300026ed2ed78d4634b0d5842a9da9bad5ad261L8-R19))

### Enhancements to code generation and error handling:

* **Generated main function in `examples/hello/main.go`**: Replaced the placeholder `main` function with a more structured, flag-driven implementation, including enhanced error handling using `slog`. This improves the usability and clarity of the generated code. (`examples/hello/main.go`, [examples/hello/main.goR8-R50](diffhunk://#diff-c6d6d44d2e3422e99aeee8890b689dc7c3d40675f2c4a23fea9f4b986c77d123R8-R50))
* **Improved logic in `scanMain` function**: Removed outdated logic for handling package files and replaced it with a streamlined approach that ensures the target file is always included in analysis while avoiding duplicates. (`cmd/goat/main.go`, [cmd/goat/main.goL229-L241](diffhunk://#diff-f73f4bf5b0f8ab54dbaee0089300026ed2ed78d4634b0d5842a9da9bad5ad261L229-L241))
* **Removed unused variables and comments**: Cleaned up unused variables and outdated comments in the `runGoat` and `scanMain` functions, simplifying the codebase and improving readability. (`cmd/goat/main.go`, [[1]](diffhunk://#diff-f73f4bf5b0f8ab54dbaee0089300026ed2ed78d4634b0d5842a9da9bad5ad261L171-L179) [[2]](diffhunk://#diff-f73f4bf5b0f8ab54dbaee0089300026ed2ed78d4634b0d5842a9da9bad5ad261L266)