### PR TITLE
Refactor environment variable handling and required field validation

### DIFF
--- a/examples/fullset/main.go
+++ b/examples/fullset/main.go
@@ -89,6 +89,7 @@ func run(opts Options) error {
 }
 
 func main() {
+	isFlagExplicitlySet := make(map[string]bool)
 
 	flag.Usage = func() {
 		fmt.Fprint(os.Stderr, `main - run is the core logic for this simple CLI tool.
@@ -116,82 +117,70 @@ Flags:
 
 	var options = &Options{}
 
-	flag.StringVar(&options.Name, "name", "World", "Name of the person to greet. This is a mandatory field." /* Default: World */)
+	var defaultName string = "World"
+
+	if val, ok := os.LookupEnv("SIMPLE_NAME"); ok {
+		defaultName = val
+	}
+
+	flag.StringVar(&options.Name, "name", defaultName, "Name of the person to greet. This is a mandatory field." /* Original Default: World, Env: SIMPLE_NAME */)
+
+	options.Age = new(int)
 
 	flag.IntVar(options.Age, "age", 0, "Age of the person. This is an optional field.")
 
-	flag.StringVar(&options.LogLevel, "log-level", "info", `LogLevel for the application output.
-It can be one of: debug, info, warning, error.` /* Default: info */)
+	var defaultLogLevel string = "info"
 
-	flag.StringVar(&options.OutputDir, "output-dir", "output", `OutputDir for any generated files or reports.
-Defaults to "output" if not specified by the user.` /* Default: output */)
+	if val, ok := os.LookupEnv("SIMPLE_LOG_LEVEL"); ok {
+		defaultLogLevel = val
+	}
 
-	flag.StringVar(&options.Mode, "mode", "", "Mode of operation for the tool, affecting its behavior.")
+	flag.StringVar(&options.LogLevel, "log-level", defaultLogLevel, `LogLevel for the application output.
+It can be one of: debug, info, warning, error.` /* Original Default: info, Env: SIMPLE_LOG_LEVEL */)
 
-	flag.BoolVar(&options.SuperVerbose, "super-verbose", false, "Enable extra verbose output.")
+	var defaultOutputDir string = "output"
+
+	flag.StringVar(&options.OutputDir, "output-dir", defaultOutputDir, `OutputDir for any generated files or reports.
+Defaults to "output" if not specified by the user.` /* Original Default: output, Env:  */)
+
+	var defaultMode string = ""
+
+	if val, ok := os.LookupEnv("SIMPLE_MODE"); ok {
+		defaultMode = val
+	}
+
+	flag.StringVar(&options.Mode, "mode", defaultMode, "Mode of operation for the tool, affecting its behavior." /* Env: SIMPLE_MODE */)
+
+	var defaultSuperVerbose bool = false
+
+	if val, ok := os.LookupEnv("SIMPLE_SUPER_VERBOSE"); ok {
+		if v, err := strconv.ParseBool(val); err == nil {
+			defaultSuperVerbose = v
+		} else {
+			slog.Warn("Could not parse environment variable as bool for default value", "envVar", "SIMPLE_SUPER_VERBOSE", "value", val, "error", err)
+		}
+	}
+
+	flag.BoolVar(&options.SuperVerbose, "super-verbose", defaultSuperVerbose, "Enable extra verbose output." /* Env: SIMPLE_SUPER_VERBOSE */)
 
 	flag.Parse()
+	flag.Visit(func(f *flag.Flag) { isFlagExplicitlySet[f.Name] = true })
 
-	if val, ok := os.LookupEnv("SIMPLE_NAME"); ok {
-		// If flag was set, it takes precedence. Only use env if flag is still its zero value.
-		// This check is tricky for bools where false is a valid value AND the default.
-		// And for numbers where 0 is a valid value AND the default.
-		// A more robust way might involve checking if the flag was explicitly set using flag.Visit().
-		// For now, if default is zero-value, env var will override if set.
-		// If default is non-zero, flag value (even if it's the default) takes precedence.
+	if !isFlagExplicitlySet["age"] {
+		if val, ok := os.LookupEnv("SIMPLE_AGE"); ok {
 
-		if options.Name == "World" { // only override if flag is still at default
-			options.Name = val
-		}
-
-	}
-
-	if options.Name == "" {
-		slog.Error("Missing required flag", "flag", "name", "envVar", "SIMPLE_NAME")
-		os.Exit(1)
-	}
-
-	if val, ok := os.LookupEnv("SIMPLE_AGE"); ok {
-		// If flag was set, it takes precedence. Only use env if flag is still its zero value.
-		// This check is tricky for bools where false is a valid value AND the default.
-		// And for numbers where 0 is a valid value AND the default.
-		// A more robust way might involve checking if the flag was explicitly set using flag.Visit().
-		// For now, if default is zero-value, env var will override if set.
-		// If default is non-zero, flag value (even if it's the default) takes precedence.
-
-		// Check if the flag was already set. If so, it takes precedence.
-		// This is a simplified check; flag.Visit would be more robust.
-		// Assuming options.Age is initialized by flag.IntVar.
-		if options.Age != nil && *options.Age == 0 {
 			if v, err := strconv.Atoi(val); err == nil {
 				*options.Age = v
 			} else {
 				slog.Warn("Could not parse environment variable as *int", "envVar", "SIMPLE_AGE", "value", val, "error", err)
 			}
-		} else if options.Age == nil { // If the pointer itself is nil (e.g. flag not processed or no default)
-			if v, err := strconv.Atoi(val); err == nil {
-				// Allocate and set
-				temp := v
-				options.Age = &temp
-			} else {
-				slog.Warn("Could not parse environment variable as *int (nil pointer)", "envVar", "SIMPLE_AGE", "value", val, "error", err)
-			}
-		}
 
+		}
 	}
 
-	if val, ok := os.LookupEnv("SIMPLE_LOG_LEVEL"); ok {
-		// If flag was set, it takes precedence. Only use env if flag is still its zero value.
-		// This check is tricky for bools where false is a valid value AND the default.
-		// And for numbers where 0 is a valid value AND the default.
-		// A more robust way might involve checking if the flag was explicitly set using flag.Visit().
-		// For now, if default is zero-value, env var will override if set.
-		// If default is non-zero, flag value (even if it's the default) takes precedence.
-
-		if options.LogLevel == "info" { // only override if flag is still at default
-			options.LogLevel = val
-		}
-
+	if options.Name == "" {
+		slog.Error("Missing required flag", "flag", "name", "envVar", "SIMPLE_NAME")
+		os.Exit(1)
 	}
 
 	if options.LogLevel == "" {
@@ -213,33 +202,9 @@ Defaults to "output" if not specified by the user.` /* Default: output */)
 		os.Exit(1)
 	}
 
-	if val, ok := os.LookupEnv("SIMPLE_FEATURES"); ok {
-		// If flag was set, it takes precedence. Only use env if flag is still its zero value.
-		// This check is tricky for bools where false is a valid value AND the default.
-		// And for numbers where 0 is a valid value AND the default.
-		// A more robust way might involve checking if the flag was explicitly set using flag.Visit().
-		// For now, if default is zero-value, env var will override if set.
-		// If default is non-zero, flag value (even if it's the default) takes precedence.
-
-	}
-
 	if options.OutputDir == "" {
 		slog.Error("Missing required flag", "flag", "output-dir")
 		os.Exit(1)
-	}
-
-	if val, ok := os.LookupEnv("SIMPLE_MODE"); ok {
-		// If flag was set, it takes precedence. Only use env if flag is still its zero value.
-		// This check is tricky for bools where false is a valid value AND the default.
-		// And for numbers where 0 is a valid value AND the default.
-		// A more robust way might involve checking if the flag was explicitly set using flag.Visit().
-		// For now, if default is zero-value, env var will override if set.
-		// If default is non-zero, flag value (even if it's the default) takes precedence.
-
-		if options.Mode == "" { // only override if flag is still at default
-			options.Mode = val
-		}
-
 	}
 
 	if options.Mode == "" {
@@ -259,35 +224,6 @@ Defaults to "output" if not specified by the user.` /* Default: output */)
 	if !isValidChoice_Mode {
 		slog.Error("Invalid value for flag", "flag", "mode", "value", options.Mode, "allowedChoices", strings.Join(allowedChoices_Mode, ", "))
 		os.Exit(1)
-	}
-
-	if val, ok := os.LookupEnv("SIMPLE_SUPER_VERBOSE"); ok {
-		// If flag was set, it takes precedence. Only use env if flag is still its zero value.
-		// This check is tricky for bools where false is a valid value AND the default.
-		// And for numbers where 0 is a valid value AND the default.
-		// A more robust way might involve checking if the flag was explicitly set using flag.Visit().
-		// For now, if default is zero-value, env var will override if set.
-		// If default is non-zero, flag value (even if it's the default) takes precedence.
-
-		// For bools, if the default is false, and the env var is "true", we set it.
-		// If the default is true, we only change if env var is explicitly "false".
-		// This avoids overriding a true default with a missing or invalid env var.
-		if defaultValForBool_SuperVerbose := false; !defaultValForBool_SuperVerbose {
-			// Only generate this block if DefaultValue is actually false
-			if v, err := strconv.ParseBool(val); err == nil && v { // Only set to true if default is false
-				options.SuperVerbose = true
-			} else if err != nil {
-				slog.Warn("Could not parse environment variable as bool", "envVar", "SIMPLE_SUPER_VERBOSE", "value", val, "error", err)
-			}
-
-		} else { // Default is true
-			if v, err := strconv.ParseBool(val); err == nil && !v { // Only set to false if default is true and env is "false"
-				options.SuperVerbose = false
-			} else if err != nil && val != "" { // Don't warn if env var is just not set for a true default
-				slog.Warn("Could not parse environment variable as bool", "envVar", "SIMPLE_SUPER_VERBOSE", "value", val, "error", err)
-			}
-		}
-
 	}
 
 	err := run(*options)

--- a/internal/codegen/main_generator.go
+++ b/internal/codegen/main_generator.go
@@ -10,6 +10,184 @@ import (
 	"github.com/podhmo/goat/internal/utils/stringutils"
 )
 
+const mainFuncTmpl = `
+func main() {
+	isFlagExplicitlySet := make(map[string]bool)
+
+	{{if .HelpText}}
+	flag.Usage = func() {
+		fmt.Fprint(os.Stderr, {{FormatHelpText .HelpText}})
+	}
+	{{end}}
+
+	{{if .HasOptions}}
+	var options = &{{.RunFunc.OptionsArgTypeNameStripped}}{}
+	{{range .Options}}
+	{{if eq .TypeName "string"}}
+	var default{{.Name}} string = {{if .DefaultValue}}{{printf "%q" .DefaultValue}}{{else}}""{{end}}
+	{{if .EnvVar}}
+	if val, ok := os.LookupEnv("{{.EnvVar}}"); ok {
+		default{{.Name}} = val
+	}
+	{{end}}
+	flag.StringVar(&options.{{.Name}}, "{{ KebabCase .Name }}", default{{.Name}}, {{FormatHelpText .HelpText}} {{- if ne .DefaultValue nil -}}/* Original Default: {{.DefaultValue}}, Env: {{.EnvVar}} */{{- else if .EnvVar}}/* Env: {{.EnvVar}} */{{- end -}})
+	{{else if eq .TypeName "int"}}
+	var default{{.Name}} int = {{if .DefaultValue}}{{.DefaultValue}}{{else}}0{{end}}
+	{{if .EnvVar}}
+	if val, ok := os.LookupEnv("{{.EnvVar}}"); ok {
+		if v, err := strconv.Atoi(val); err == nil {
+			default{{.Name}} = v
+		} else {
+			slog.Warn("Could not parse environment variable as int for default value", "envVar", "{{.EnvVar}}", "value", val, "error", err)
+		}
+	}
+	{{end}}
+	flag.IntVar(&options.{{.Name}}, "{{ KebabCase .Name }}", default{{.Name}}, {{FormatHelpText .HelpText}} {{- if ne .DefaultValue nil -}}/* Original Default: {{.DefaultValue}}, Env: {{.EnvVar}} */{{- else if .EnvVar}}/* Env: {{.EnvVar}} */{{- end -}})
+	{{else if eq .TypeName "bool"}}
+	var default{{.Name}} bool = {{if .DefaultValue}}{{.DefaultValue}}{{else}}false{{end}}
+	{{if .EnvVar}}
+	if val, ok := os.LookupEnv("{{.EnvVar}}"); ok {
+		if v, err := strconv.ParseBool(val); err == nil {
+			default{{.Name}} = v
+		} else {
+			slog.Warn("Could not parse environment variable as bool for default value", "envVar", "{{.EnvVar}}", "value", val, "error", err)
+		}
+	}
+	{{end}}
+	{{if and .IsRequired (eq (.DefaultValue | printf "%v") "true") }}
+	options.{{.Name}} = default{{.Name}}
+	var {{.Name}}_NoFlagIsPresent bool
+	flag.BoolVar(&{{.Name}}_NoFlagIsPresent, "no-{{ KebabCase .Name }}", false, {{FormatHelpText .HelpText}})
+	{{else}}
+	flag.BoolVar(&options.{{.Name}}, "{{ KebabCase .Name }}", default{{.Name}}, {{FormatHelpText .HelpText}} {{- if ne .DefaultValue nil -}}/* Original Default: {{.DefaultValue}}, Env: {{.EnvVar}} */{{- else if .EnvVar}}/* Env: {{.EnvVar}} */{{- end -}})
+	{{end}}
+	{{else if eq .TypeName "*string"}}
+	options.{{.Name}} = new(string)
+	{{if .DefaultValue}}*options.{{.Name}} = {{printf "%q" .DefaultValue}}{{end}}
+	flag.StringVar(options.{{.Name}}, "{{ KebabCase .Name }}", {{if .DefaultValue}}{{printf "%q" .DefaultValue}}{{else}}""{{end}}, {{FormatHelpText .HelpText}}   {{- if ne .DefaultValue nil -}}/* Default: {{.DefaultValue}} */{{- end -}})
+	{{else if eq .TypeName "*int"}}
+	options.{{.Name}} = new(int)
+	{{if .DefaultValue}}*options.{{.Name}} = {{.DefaultValue}}{{end}}
+	flag.IntVar(options.{{.Name}}, "{{ KebabCase .Name }}", {{if .DefaultValue}}{{.DefaultValue}}{{else}}0{{end}}, {{FormatHelpText .HelpText}}{{- if ne .DefaultValue nil -}}/* Default: {{.DefaultValue}} */{{- end -}})
+	{{else if eq .TypeName "*bool"}}
+	options.{{.Name}} = new(bool)
+	{{if .DefaultValue}}*options.{{.Name}} = {{.DefaultValue}}{{end}}
+	flag.BoolVar(options.{{.Name}}, "{{ KebabCase .Name }}", {{if ne .DefaultValue nil}}{{.DefaultValue}}{{else}}false{{end}}, {{FormatHelpText .HelpText}}{{- if ne .DefaultValue nil -}}/* Default: {{.DefaultValue}} */{{- end -}})
+	{{end}}
+	{{end}}
+	{{end}}
+
+	flag.Parse()
+	flag.Visit(func(f *flag.Flag) { isFlagExplicitlySet[f.Name] = true })
+
+	{{if .HasOptions}}
+	{{range .Options}}
+	{{if eq .TypeName "bool"}}
+	{{if and .IsRequired (eq (.DefaultValue | printf "%v") "true") }}
+	if {{.Name}}_NoFlagIsPresent {
+		options.{{.Name}} = false
+	}
+	{{end}}
+	{{end}}
+	{{end}}
+
+	{{range .Options}}
+	{{if or (eq .TypeName "*string") (eq .TypeName "*int") (eq .TypeName "*bool")}}
+	{{if .EnvVar}}
+	if !isFlagExplicitlySet["{{ KebabCase .Name }}"] {
+		if val, ok := os.LookupEnv("{{.EnvVar}}"); ok {
+			{{if eq .TypeName "*string"}}
+			*options.{{.Name}} = val
+			{{else if eq .TypeName "*int"}}
+			if v, err := strconv.Atoi(val); err == nil {
+				*options.{{.Name}} = v
+			} else {
+				slog.Warn("Could not parse environment variable as *int", "envVar", "{{.EnvVar}}", "value", val, "error", err)
+			}
+			{{else if eq .TypeName "*bool"}}
+			if v, err := strconv.ParseBool(val); err == nil {
+				*options.{{.Name}} = v
+			} else {
+				slog.Warn("Could not parse environment variable as *bool", "envVar", "{{.EnvVar}}", "value", val, "error", err)
+			}
+			{{end}}
+		}
+	}
+	{{end}}
+	{{end}}
+	{{end}}
+
+	{{range .Options}}
+	{{if .IsRequired}}
+	{{if eq .TypeName "string"}}
+	var env{{.Name}}IsSet bool
+	{{if .EnvVar}}
+	if _, ok := os.LookupEnv("{{.EnvVar}}"); ok {
+		env{{.Name}}IsSet = true
+	}
+	{{end}}
+	if options.{{.Name}} == {{if .DefaultValue}}{{printf "%q" .DefaultValue}}{{else}}""{{end}} &&
+	   !isFlagExplicitlySet["{{KebabCase .Name}}"] &&
+	   !env{{.Name}}IsSet {
+		slog.Error("Missing required flag", "flag", "{{KebabCase .Name}}"{{if .EnvVar}}, "envVar", "{{.EnvVar}}"{{end}})
+		os.Exit(1)
+	}
+	{{else if eq .TypeName "int"}}
+	var env{{.Name}}IsSet bool
+	{{if .EnvVar}}
+	if _, ok := os.LookupEnv("{{.EnvVar}}"); ok {
+		env{{.Name}}IsSet = true
+	}
+	{{end}}
+	if options.{{.Name}} == {{if .DefaultValue}}{{.DefaultValue}}{{else}}0{{end}} &&
+	   !isFlagExplicitlySet["{{KebabCase .Name}}"] &&
+	   !env{{.Name}}IsSet {
+		slog.Error("Missing required flag", "flag", "{{KebabCase .Name}}"{{if .EnvVar}}, "envVar", "{{.EnvVar}}"{{end}})
+		os.Exit(1)
+	}
+	{{else if eq .TypeName "*string"}}
+	if options.{{.Name}} == nil || *options.{{.Name}} == "" {
+		slog.Error("Missing required flag or empty value for", "flag", "{{KebabCase .Name}}"{{if .EnvVar}}, "envVar", "{{.EnvVar}}"{{end}})
+		os.Exit(1)
+	}
+	{{else if or (eq .TypeName "*int") (eq .TypeName "*bool")}}
+	if options.{{.Name}} == nil {
+		slog.Error("Missing required flag", "flag", "{{KebabCase .Name}}"{{if .EnvVar}}, "envVar", "{{.EnvVar}}"{{end}})
+		os.Exit(1)
+	}
+	{{end}}
+	{{end}}
+
+	{{if .EnumValues}}
+	isValidChoice_{{.Name}} := false
+	allowedChoices_{{.Name}} := []string{ {{range $i, $e := .EnumValues}}{{if $i}}, {{end}}{{printf "%q" $e}}{{end}} }
+	currentValue_{{.Name}}Str := fmt.Sprintf("%v", options.{{.Name}})
+	for _, choice := range allowedChoices_{{.Name}} {
+		if currentValue_{{.Name}}Str == choice {
+			isValidChoice_{{.Name}} = true
+			break
+		}
+	}
+	if !isValidChoice_{{.Name}} {
+		slog.Error("Invalid value for flag", "flag", "{{ KebabCase .Name }}", "value", options.{{.Name}}, "allowedChoices", strings.Join(allowedChoices_{{.Name}}, ", "))
+		os.Exit(1)
+	}
+	{{end}}
+	{{end}}
+	{{end}}
+
+	{{if .HasOptions}}
+	err := {{.RunFunc.Name}}( {{if .RunFunc.OptionsArgIsPointer}} options {{else}} *options {{end}} )
+	{{else}}
+	err := {{.RunFunc.Name}}()
+	{{end}}
+	if err != nil {
+		slog.Error("Runtime error", "error", err)
+		os.Exit(1)
+	}
+}
+`
+
 // formatHelpText formats the help text string for inclusion in the generated Go code.
 // It handles escaped newlines (\\n) and placeholder single quotes (') for backticks (`).
 // It then chooses the best Go string literal representation.
@@ -66,206 +244,7 @@ func GenerateMain(cmdMeta *metadata.CommandMetadata, helpText string, generateFu
 		"FormatHelpText": formatHelpText, // Add this line
 	}
 
-	tmpl := template.Must(template.New("main").Funcs(templateFuncs).Parse(`
-func main() {
-	{{if .HelpText}}
-	flag.Usage = func() {
-		fmt.Fprint(os.Stderr, {{FormatHelpText .HelpText}})
-	}
-	{{end}}
-
-	{{if .HasOptions}}
-	var options = &{{.RunFunc.OptionsArgTypeNameStripped}}{}
-	{{range .Options}}
-	{{if eq .TypeName "string"}}
-	flag.StringVar(&options.{{.Name}}, "{{ KebabCase .Name }}", {{if .DefaultValue}}{{printf "%q" .DefaultValue}}{{else}}""{{end}}, {{FormatHelpText .HelpText}}   {{- if ne .DefaultValue nil -}}/* Default: {{.DefaultValue}} */{{- end -}})
-	{{else if eq .TypeName "int"}}
-	flag.IntVar(&options.{{.Name}}, "{{ KebabCase .Name }}", {{if .DefaultValue}}{{.DefaultValue}}{{else}}0{{end}}, {{FormatHelpText .HelpText}}{{- if ne .DefaultValue nil -}}/* Default: {{.DefaultValue}} */{{- end -}})
-	{{else if eq .TypeName "bool"}}
-	{{if and .IsRequired (ne .DefaultValue nil) (eq .DefaultValue true)}}
-	var {{.Name}}_NoFlagIsPresent bool
-	flag.BoolVar(&{{.Name}}_NoFlagIsPresent, "no-{{ KebabCase .Name }}", false, {{FormatHelpText .HelpText}})
-	{{else}}
-	flag.BoolVar(&options.{{.Name}}, "{{ KebabCase .Name }}", {{if ne .DefaultValue nil}}{{.DefaultValue}}{{else}}false{{end}}, {{FormatHelpText .HelpText}}{{- if ne .DefaultValue nil -}}/* Default: {{.DefaultValue}} */{{- end -}})
-	{{end}}
-	{{else if eq .TypeName "*string"}}
-	flag.StringVar(options.{{.Name}}, "{{ KebabCase .Name }}", {{if .DefaultValue}}{{printf "%q" .DefaultValue}}{{else}}""{{end}}, {{FormatHelpText .HelpText}}   {{- if ne .DefaultValue nil -}}/* Default: {{.DefaultValue}} */{{- end -}})
-	{{else if eq .TypeName "*int"}}
-	flag.IntVar(options.{{.Name}}, "{{ KebabCase .Name }}", {{if .DefaultValue}}{{.DefaultValue}}{{else}}0{{end}}, {{FormatHelpText .HelpText}}{{- if ne .DefaultValue nil -}}/* Default: {{.DefaultValue}} */{{- end -}})
-	{{else if eq .TypeName "*bool"}}
-	flag.BoolVar(options.{{.Name}}, "{{ KebabCase .Name }}", {{if ne .DefaultValue nil}}{{.DefaultValue}}{{else}}false{{end}}, {{FormatHelpText .HelpText}}{{- if ne .DefaultValue nil -}}/* Default: {{.DefaultValue}} */{{- end -}})
-	{{end}}
-	{{end}}
-	{{end}}
-
-	flag.Parse()
-
-	{{if .HasOptions}}
-	{{range .Options}}
-	{{if eq .TypeName "bool"}}
-	{{if and .IsRequired (ne .DefaultValue nil) (eq .DefaultValue true)}}
-	options.{{.Name}} = true // Default to true
-	if {{.Name}}_NoFlagIsPresent { // If --no-{{KebabCase .Name}} was present
-		options.{{.Name}} = false
-	}
-	{{end}}
-	{{end}}
-	{{if .EnvVar}}
-	if val, ok := os.LookupEnv("{{.EnvVar}}"); ok {
-		// If flag was set, it takes precedence. Only use env if flag is still its zero value.
-		// This check is tricky for bools where false is a valid value AND the default.
-		// And for numbers where 0 is a valid value AND the default.
-		// A more robust way might involve checking if the flag was explicitly set using flag.Visit().
-		// For now, if default is zero-value, env var will override if set.
-		// If default is non-zero, flag value (even if it's the default) takes precedence.
-		{{if eq .TypeName "string"}}
-		if options.{{.Name}} == {{if .DefaultValue}}{{printf "%q" .DefaultValue}}{{else}}""{{end}} { // only override if flag is still at default
-			options.{{.Name}} = val
-		}
-		{{else if eq .TypeName "int"}}
-		if options.{{.Name}} == {{if .DefaultValue}}{{.DefaultValue}}{{else}}0{{end}} {
-			if v, err := strconv.Atoi(val); err == nil {
-				options.{{.Name}} = v
-			} else {
-				slog.Warn("Could not parse environment variable as int", "envVar", "{{.EnvVar}}", "value", val, "error", err)
-			}
-		}
-		{{else if eq .TypeName "bool"}}
-		// For bools, if the default is false, and the env var is "true", we set it.
-		// If the default is true, we only change if env var is explicitly "false".
-		// This avoids overriding a true default with a missing or invalid env var.
-		if defaultValForBool_{{.Name}} := {{if .DefaultValue}}{{.DefaultValue}}{{else}}false{{end}}; !defaultValForBool_{{.Name}} {
-			{{if not .DefaultValue}} // Only generate this block if DefaultValue is actually false
-			if v, err := strconv.ParseBool(val); err == nil && v { // Only set to true if default is false
-				options.{{.Name}} = true
-			} else if err != nil {
-				slog.Warn("Could not parse environment variable as bool", "envVar", "{{.EnvVar}}", "value", val, "error", err)
-			}
-			{{end}}
-		} else { // Default is true
-			if v, err := strconv.ParseBool(val); err == nil && !v { // Only set to false if default is true and env is "false"
-				options.{{.Name}} = false
-			} else if err != nil && val != "" { // Don't warn if env var is just not set for a true default
-				slog.Warn("Could not parse environment variable as bool", "envVar", "{{.EnvVar}}", "value", val, "error", err)
-			}
-		}
-		{{else if eq .TypeName "*int"}}
-		// Check if the flag was already set. If so, it takes precedence.
-		// This is a simplified check; flag.Visit would be more robust.
-		// Assuming options.{{.Name}} is initialized by flag.IntVar.
-		if options.{{.Name}} != nil && *options.{{.Name}} == {{if .DefaultValue}}{{.DefaultValue}}{{else}}0{{end}} {
-			if v, err := strconv.Atoi(val); err == nil {
-				*options.{{.Name}} = v
-			} else {
-				slog.Warn("Could not parse environment variable as *int", "envVar", "{{.EnvVar}}", "value", val, "error", err)
-			}
-		} else if options.{{.Name}} == nil { // If the pointer itself is nil (e.g. flag not processed or no default)
-			if v, err := strconv.Atoi(val); err == nil {
-				// Allocate and set
-				temp := v
-				options.{{.Name}} = &temp
-			} else {
-				slog.Warn("Could not parse environment variable as *int (nil pointer)", "envVar", "{{.EnvVar}}", "value", val, "error", err)
-			}
-		}
-		{{else if eq .TypeName "*string"}}
-		// Check if the flag was already set (simplified check)
-		if options.{{.Name}} != nil && *options.{{.Name}} == {{if .DefaultValue}}{{printf "%q" .DefaultValue}}{{else}}""{{end}} {
-			*options.{{.Name}} = val
-		} else if options.{{.Name}} == nil { // If the pointer itself is nil
-			temp := val
-			options.{{.Name}} = &temp
-		}
-		{{else if eq .TypeName "*bool"}}
-		// Simplified check: only override if current value is default.
-		// Assumes options.{{.Name}} is non-nil due to flag processing, or handles nil if not.
-		expectedDefaultBool := {{if .DefaultValue}}{{.DefaultValue}}{{else}}false{{end}}
-		currentValueMatchesDefault := false
-		if options.{{.Name}} != nil && *options.{{.Name}} == expectedDefaultBool {
-			currentValueMatchesDefault = true
-		}
-
-		if currentValueMatchesDefault || options.{{.Name}} == nil {
-			if v, err := strconv.ParseBool(val); err == nil {
-				if options.{{.Name}} == nil {
-					temp := v
-					options.{{.Name}} = &temp
-				} else {
-					*options.{{.Name}} = v
-				}
-			} else {
-				slog.Warn("Could not parse environment variable as *bool", "envVar", "{{.EnvVar}}", "value", val, "error", err)
-			}
-		}
-		{{end}}
-	}
-	{{end}}
-
-	{{if .IsRequired}}
-	{{if eq .TypeName "string"}}
-	if options.{{.Name}} == "" {
-		slog.Error("Missing required flag", "flag", "{{ KebabCase .Name }}"{{if .EnvVar}}, "envVar", "{{.EnvVar}}"{{end}})
-		os.Exit(1)
-	}
-	{{else if eq .TypeName "int"}}
-	// Check if the int flag was explicitly set or came from an env var,
-	// especially if its value is the same as the default.
-	// This is important if the default is 0, which is also the zero value for int.
-	isSetOrFromEnv_{{.Name}} := false
-	flag.Visit(func(f *flag.Flag) {
-		if f.Name == "{{ KebabCase .Name }}" {
-			isSetOrFromEnv_{{.Name}} = true
-		}
-	})
-	{{if .EnvVar}}
-	if !isSetOrFromEnv_{{.Name}} {
-		if val, ok := os.LookupEnv("{{.EnvVar}}"); ok {
-			// Check if env var could have been the source
-			if parsedVal, err := strconv.Atoi(val); err == nil && parsedVal == options.{{.Name}} {
-				isSetOrFromEnv_{{.Name}} = true
-			}
-		}
-	}
-	{{end}}
-	if !isSetOrFromEnv_{{.Name}} && options.{{.Name}} == {{if .DefaultValue}}{{.DefaultValue}}{{else}}0{{end}} {
-		// If it wasn't set via flag or a matching env var, and it's still the default value,
-		// then it's considered missing.
-		slog.Error("Missing required flag", "flag", "{{ KebabCase .Name }}"{{if .EnvVar}}, "envVar", "{{.EnvVar}}"{{end}})
-		os.Exit(1)
-	}
-	{{end}}
-
-	{{end}}
-
-	{{if .EnumValues}}
-	isValidChoice_{{.Name}} := false
-	allowedChoices_{{.Name}} := []string{ {{range $i, $e := .EnumValues}}{{if $i}}, {{end}}{{printf "%q" $e}}{{end}} }
-	currentValue_{{.Name}}Str := fmt.Sprintf("%v", options.{{.Name}})
-	for _, choice := range allowedChoices_{{.Name}} {
-		if currentValue_{{.Name}}Str == choice {
-			isValidChoice_{{.Name}} = true
-			break
-		}
-	}
-	if !isValidChoice_{{.Name}} {
-		slog.Error("Invalid value for flag", "flag", "{{ KebabCase .Name }}", "value", options.{{.Name}}, "allowedChoices", strings.Join(allowedChoices_{{.Name}}, ", "))
-		os.Exit(1)
-	}
-	{{end}}
-	{{end}}
-	{{end}}
-
-	{{if .HasOptions}}
-	err := {{.RunFunc.Name}}( {{if .RunFunc.OptionsArgIsPointer}} options {{else}} *options {{end}} )
-	{{else}}
-	err := {{.RunFunc.Name}}()
-	{{end}}
-	if err != nil {
-		slog.Error("Runtime error", "error", err)
-		os.Exit(1)
-	}
-}
-`))
+	tmpl := template.Must(template.New("main").Funcs(templateFuncs).Parse(mainFuncTmpl))
 
 	if len(cmdMeta.Options) > 0 && cmdMeta.RunFunc.OptionsArgTypeNameStripped == "" {
 		return "", fmt.Errorf("OptionsArgTypeNameStripped is empty for command %s, but options are present. This indicates an issue with parsing the run function's options struct type", cmdMeta.Name)


### PR DESCRIPTION
This commit introduces a comprehensive refactoring of how environment variables are handled in the code generated for `main()` functions. It also improves the validation logic for required fields, especially those whose default values are their type's zero value.

Key changes:

1.  **Environment Variable Precedence for Non-Pointer Types:**
    - Environment variables now influence the default values for non-pointer type options (`string`, `int`, `bool`) *before* `flag.Parse()` is called.
    - If an environment variable is set and valid for an option, its value is used as the default for the corresponding command-line flag.
    - If the env var is not set or invalid, the original default from the metadata (struct tags or `goat.Default`) is used.
    - This simplifies precedence, as `flag.Parse()` naturally allows explicit command-line flags to override these defaults.

2.  **Environment Variable Handling for Pointer Types:**
    - For pointer types (`*string`, `*int`, `*bool`), environment variables are processed *after* `flag.Parse()`.
    - The `flag.Visit()` function is used to determine if a flag for a pointer option was explicitly set on the command line.
    - If the flag was *not* set and a corresponding environment variable is found and valid, the pointer option is allocated (if necessary) and its dereferenced value is set from the environment variable.
    - Pointers are now consistently allocated with `new(Type)` during flag definition to ensure they are not nil when `flag.TypeVar` is called.

3.  **Refined `IsRequired` Validation:**
    - The validation logic for required `int` and `string` fields whose default value is their type's zero value (e.g., `0` for `int`, `""` for `string`) has been significantly improved.
    - An error is now correctly reported if such a field's value remains its original default, the command-line flag was not explicitly set, AND the corresponding environment variable was also not set. This distinguishes true "missing" values from explicitly set zero values.
    - Required pointer field validation (`*string` must not be nil or empty, `*int`/`*bool` must not be nil) is also in place.

4.  **Syntax Error Fixes and Code Generation Improvements:**
    - Several syntax errors within the `internal/codegen/main_generator.go` template, identified during development, have been fixed.
    - The main Go template string was refactored into a `const` for better readability and to avoid Go parser issues with inline raw string literals containing comments.

These changes make the generated CLI tools more robust and predictable in their handling of command-line flags and environment variables, and ensure that required fields are validated more accurately.