### PR TITLE
Add test for internal/metadata package

### DIFF
--- a/internal/metadata/metadata_test.go
+++ b/internal/metadata/metadata_test.go
@@ -1,0 +1,16 @@
+package metadata
+
+import "testing"
+
+func TestCommandMetadata(t *testing.T) {
+	t.Run("create command metadata", func(t *testing.T) {
+		name := "test-command"
+		md := CommandMetadata{
+			Name: name,
+		}
+
+		if md.Name != name {
+			t.Errorf("expected Name to be %q, but got %q", name, md.Name)
+		}
+	})
+}


### PR DESCRIPTION
I added a simple test file and test case for the internal/metadata package, which previously had no tests. This ensures basic functionality and improves test coverage for you.