### PR TITLE
Fix: Do not show '(required)' in help if default value exists

### DIFF
--- a/cmd/goat/main_test.go
+++ b/cmd/goat/main_test.go
@@ -56,8 +56,8 @@ Usage:
   main [flags]
 
 Flags:
-  --name            string   Name of the user. (required) (default: "anonymous")
-  --port            int      Port number. (required) (default: 8080)
+  --name            string   Name of the user. (default: "anonymous")
+  --port            int      Port number. (default: 8080)
   --verbose         bool     Verbose flag.
   --no-enable-magic bool     Enable magic feature.
 
@@ -150,10 +150,10 @@ func TestHelpGenerateHelpOutput(t *testing.T) {
 	if !strings.Contains(got, "main - Run the test application.") {
 		t.Errorf("Generated help output does not contain command description.\nGot:\n%s", got)
 	}
-	if !strings.Contains(got, "--name            string   Name of the user. (required) (default: \"anonymous\")") {
+	if !strings.Contains(got, "--name            string   Name of the user. (default: \"anonymous\")") {
 		t.Errorf("Generated help output does not contain --name flag details.\nGot:\n%s", got)
 	}
-	if !strings.Contains(got, "--port            int      Port number. (required) (default: 8080)") {
+	if !strings.Contains(got, "--port            int      Port number. (default: 8080)") {
 		t.Errorf("Generated help output does not contain --port flag details.\nGot:\n%s", got)
 	}
 	// Normalize line endings and trim overall whitespace.

--- a/examples/fullset/main.go
+++ b/examples/fullset/main.go
@@ -101,14 +101,14 @@ Usage:
   main [flags]
 
 Flags:
-  --name          string   Name of the person to greet. This is a mandatory field. (required) (default: "World") (env: SIMPLE_NAME)
+  --name          string   Name of the person to greet. This is a mandatory field. (default: "World") (env: SIMPLE_NAME)
   --age           int      Age of the person. This is an optional field. (env: SIMPLE_AGE)
   --log-level     string   LogLevel for the application output.
-                         It can be one of: debug, info, warning, error. (required) (default: "info") (env: SIMPLE_LOG_LEVEL) (allowed: "debug", "info", "warning", "error")
+                         It can be one of: debug, info, warning, error. (default: "info") (env: SIMPLE_LOG_LEVEL) (allowed: "debug", "info", "warning", "error")
   --features      strings  Features to enable, provided as a comma-separated list.
                          Example: --features feat1,feat2 (required) (env: SIMPLE_FEATURES)
   --output-dir    string   OutputDir for any generated files or reports.
-                         Defaults to "output" if not specified by the user. (required) (default: "output")
+                         Defaults to "output" if not specified by the user. (default: "output")
   --mode          string   Mode of operation for the tool, affecting its behavior. (required) (env: SIMPLE_MODE) (allowed: "standard", "turbo", "eco")
   --super-verbose bool     Enable extra verbose output. (env: SIMPLE_SUPER_VERBOSE)
 

--- a/internal/help/generator.go
+++ b/internal/help/generator.go
@@ -56,7 +56,7 @@ func generateHelp(w io.Writer, cmdMeta *metadata.CommandMetadata) {
 		helpTextIndent := strings.Repeat(" ", 2+maxNameLen+1+8+1)
 		helpText := strings.ReplaceAll(opt.HelpText, "\n", "\n"+helpTextIndent)
 		fmt.Fprintf(w, "  --%-*s %-8s %s", maxNameLen, displayName, typeIndicator, helpText)
-		if opt.IsRequired && !(opt.TypeName == "bool" || opt.TypeName == "*bool") {
+		if opt.IsRequired && (opt.DefaultValue == nil || opt.DefaultValue == "") && !(opt.TypeName == "bool" || opt.TypeName == "*bool") {
 			fmt.Fprint(w, " (required)")
 		}
 

--- a/internal/help/generator_test.go
+++ b/internal/help/generator_test.go
@@ -72,28 +72,42 @@ func TestGenerateHelp_Basic(t *testing.T) {
 				IsRequired:   true,
 				DefaultValue: false,
 			},
+			{ // New option to test the core change
+				Name:         "Region",
+				CliName:      "region",
+				TypeName:     "string",
+				HelpText:     "AWS region.",
+				IsRequired:   true,
+				DefaultValue: "us-east-1",
+			},
 		},
 	}
 
 	helpMsg := GenerateHelp(cmdMeta)
 
-	// Set expected to be the actual output to re-baseline the test.
-	// This ensures the test passes and acts as a change detector for GenerateHelp's output.
-	expected := helpMsg
+	expected := `mytool - A super useful tool.
+         Does amazing things.
 
-	// Normalize line endings for consistent comparison, though GenerateHelp should produce consistent \n.
-	// It's good practice if expected could come from other sources in different scenarios.
+Usage:
+  mytool [flags]
+
+Flags:
+  --username            string   The username for login. (required) (env: APP_USER)
+  --port                int      Port number to listen on. (default: 8080)
+  --mode                string   Operation mode. (default: "dev") (allowed: "dev", "prod", "test")
+  --verbose             bool     Enable verbose output.
+  --force-push          bool     Force push changes.
+  --no-enable-auto-sync bool     Enable automatic synchronization.
+  --strict-validation   bool     Enable strict validation.
+  --region              string   AWS region. (default: "us-east-1")
+
+  -h, --help                    Show this help message and exit
+`
 	helpMsg = strings.ReplaceAll(helpMsg, "\r\n", "\n")
 	expected = strings.ReplaceAll(expected, "\r\n", "\n")
 
-	// Convert spaces to @ for robust whitespace comparison and clear diffs.
-	helpMsgAt := strings.ReplaceAll(helpMsg, " ", "@")
-	expectedAt := strings.ReplaceAll(expected, " ", "@")
-
-	if helpMsgAt != expectedAt {
-		// This block should ideally not be reached if expected is set to helpMsg.
-		// If it is, it might indicate inconsistencies from ReplaceAll or other subtle issues.
-		t.Errorf("help message mismatch (spaces shown as @)\n--- expected (derived from actual output) ---\n%s\n--- got ---\n%s", expectedAt, helpMsgAt)
+	if helpMsg != expected {
+		t.Errorf("help message mismatch:\n---EXPECTED---\n%s\n\n---ACTUAL---\n%s", expected, helpMsg)
 	}
 }
 


### PR DESCRIPTION
Previously, flags marked as required would always show '(required)' in the help message. This change updates the help generation logic to suppress the '(required)' text if a default value is specified for the flag, as the presence of a default value implies it's not strictly required for you to provide it.

Changes include:
- Modified internal/help/generator.go to update the display condition.
- Updated tests in internal/help/generator_test.go with a fixed expected output to verify the new behavior.
- Adjusted expected help output in cmd/goat/main_test.go to align with the new logic.
- Ran 'make examples-emit' to regenerate example outputs.

All tests pass with these changes.