### PR TITLE
Refactor: Adjust initializer scope and codegen

### DIFF
--- a/internal/codegen/main_generator.go
+++ b/internal/codegen/main_generator.go
@@ -26,7 +26,7 @@ func main() {
 
 	{{if .RunFunc.InitializerFunc}}
 	// 1. Create Options using the initializer function.
-	options = {{if ne .RunFunc.PackageName "main"}}{{.RunFunc.PackageName}}.{{end}}{{.RunFunc.InitializerFunc}}()
+	options = {{.RunFunc.InitializerFunc}}()
 	{{else}}
 	// 1. Create Options with default values (no initializer function provided).
 	options = new({{.RunFunc.OptionsArgTypeNameStripped}}) // options is now a valid pointer to a zeroed struct

--- a/internal/codegen/main_generator_test.go
+++ b/internal/codegen/main_generator_test.go
@@ -1057,7 +1057,8 @@ func TestGenerateMain_WithInitializer(t *testing.T) {
 	assertCodeContains(t, actualCode, `import "example.com/user/usercmd"`)
 
 	// Check for options initialization using the InitializerFunc
-	assertCodeContains(t, actualCode, "options = usercmd.NewMyOptions()")
+	// Now expects no package prefix as initializer is assumed to be in 'main' by analyzer
+	assertCodeContains(t, actualCode, "options = NewMyOptions()")
 
 	// Check that per-field default setting is NOT present
 	// (difficult to assert absence of a potentially large block,


### PR DESCRIPTION
This commit addresses an issue where the codegen incorrectly prefixed initializer function calls, leading to errors like 'undefined: hello' when the initializer was in 'package main' but in a subdirectory.

Changes:
- Updated `internal/analyzer/analyzer.go` to ensure that initializer functions (e.g., `NewOptionsType`) are only identified if they are declared in a file belonging to the CLI's `package main`.
- Modified `internal/codegen/main_generator.go` to remove the conditional package prefix from the initializer function call in the `mainFuncTmpl` template. Initializer calls are now always direct (e.g., `InitializerFunc()`).
- Updated assertions in `internal/codegen/main_generator_test.go` (specifically in `TestGenerateMain_WithInitializer`) to reflect the direct initializer calls.

With these changes, `make examples-emit` now successfully processes `examples/hello/main.go`. A failure persists with
`examples/fullset/main.go` due to an apparent pre-existing package resolution issue (`could not import github.com/podhmo/goat (invalid package name: "")`), which is considered out of scope for this refactoring.