### PR TITLE
I've made some updates to align the codegen and tests with the main p…

### DIFF
--- a/examples/fullset/main.go
+++ b/examples/fullset/main.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/podhmo/goat"
+	g "github.com/podhmo/goat"
 )
 
 //go:generate goat emit -run run -initializer newOptions main.go
@@ -46,10 +46,10 @@ type Options struct {
 // This function will be "interpreted" by the goat tool.
 func newOptions() *Options {
 	return &Options{
-		Name:      goat.Default("World"),
-		LogLevel:  goat.Default("info", goat.Enum([]string{"debug", "info", "warning", "error"})),
-		OutputDir: goat.Default("output"),
-		Mode:      goat.Enum([]string{"standard", "turbo", "eco"}),
+		Name:      g.Default("World"),
+		LogLevel:  g.Default("info", g.Enum([]string{"debug", "info", "warning", "error"})),
+		OutputDir: g.Default("output"),
+		Mode:      g.Enum([]string{"standard", "turbo", "eco"}),
 		// Age is optional (pointer) and has no default here.
 		// Features is a slice, will be handled by flag package (e.g. multiple --features flag or comma sep)
 		// SuperVerbose is a bool, defaults to false (zero value for bool)
@@ -160,7 +160,7 @@ Flags:
 	}
 
 	if val, ok := os.LookupEnv("SIMPLE_FEATURES"); ok {
-
+		options.Features = strings.Split(val, ",")
 	}
 
 	if val, ok := os.LookupEnv("SIMPLE_MODE"); ok {

--- a/examples/hello/main.go
+++ b/examples/hello/main.go
@@ -9,7 +9,8 @@ import (
 	"os"
 )
 
-type options struct {
+// Options defines the command line options.
+type Options struct {
 	Version    bool   // Print version information
 	Help       bool   // Show help message
 	ConfigFile string // Path to the configuration file
@@ -19,10 +20,10 @@ func main() {
 	isFlagExplicitlySet := make(map[string]bool)
 
 	flag.Usage = func() {
-		fmt.Fprint(os.Stderr, `main - 
+		fmt.Fprint(os.Stderr, `m/hello - run is the actual command logic.
 
 Usage:
-  main [flags]
+  m/hello [flags]
 
 Flags:
   --version     bool     Print version information
@@ -33,9 +34,13 @@ Flags:
 `)
 	}
 
-	var options = &options{}
+	var options *Options
 
-	// 1. Create Options with default values.
+	// 1. Create Options with default values (no initializer function provided).
+	options = new(Options) // options is now a valid pointer to a zeroed struct
+
+	// The following block populates the fields of the options struct.
+	// This logic is only executed if no InitializerFunc is provided.
 
 	options.Version = false
 
@@ -43,7 +48,13 @@ Flags:
 
 	options.ConfigFile = ""
 
+	// End of range .Options (for non-initializer case)
+	// End of if/else .RunFunc.InitializerFunc for options assignment
+
 	// 2. Override with environment variable values.
+	// This section assumes 'options' is already initialized.
+
+	// End of range .Options for env vars
 
 	// 3. Set flags.
 
@@ -53,6 +64,8 @@ Flags:
 
 	flag.StringVar(&options.ConfigFile, "config-file", options.ConfigFile, "Path to the configuration file")
 
+	// End of range .Options for flags
+
 	// 4. Parse.
 	flag.Parse()
 	flag.Visit(func(f *flag.Flag) { isFlagExplicitlySet[f.Name] = true })
@@ -61,9 +74,6 @@ Flags:
 
 	// 5. Perform required checks (excluding booleans).
 
-	// A string is required. It must not be its original default if the flag wasn't set and env var wasn't set.
-	// If default was empty: must not be empty.
-	// If default was non-empty: must not be that specific non-empty value.
 	initialDefaultConfigFile := ""
 	envConfigFileWasSet := false
 
@@ -73,9 +83,12 @@ Flags:
 	}
 
 	// End of range .Options for required checks
-	// End of if .HasOptions
+	// End of if .RunFunc.OptionsArgTypeNameStripped (options handling block)
 
-	err := run(*options)
+	var err error
+
+	// Run function expects an options argument
+	err = run(*options)
 
 	if err != nil {
 		slog.Error("Runtime error", "error", err)
@@ -83,6 +96,7 @@ Flags:
 	}
 }
 
-func run(options options) error {
-	return json.NewEncoder(os.Stdout).Encode(options)
+// run is the actual command logic.
+func run(opts Options) error { // Parameter type changed to Options, name to opts
+	return json.NewEncoder(os.Stdout).Encode(opts)
 }

--- a/internal/codegen/main_generator_test.go
+++ b/internal/codegen/main_generator_test.go
@@ -61,129 +61,47 @@ func assertCodeContains(t *testing.T, actualGeneratedCode, expectedSnippet strin
 }
 
 func TestGenerateMain_WithTextVarOptions(t *testing.T) {
-	// Common RunFuncInfo for these tests
 	runFuncInfo := &metadata.RunFuncInfo{
 		Name:                       "RunTextVarTest",
-		PackageName:                "main", // Assuming generated code is in main package
+		PackageName:                "main",
 		OptionsArgTypeNameStripped: "TextVarCmdOptions",
 		OptionsArgIsPointer:        true,
 	}
-
-	// Case 1: Value type MyTextValue (IsTextUnmarshaler=true, IsTextMarshaler=true)
 	optMetaValue := &metadata.OptionMetadata{
-		Name:              "FieldA",
-		CliName:           "field-a", // KebabCase will be applied by template if not set, but good to be explicit
-		TypeName:          "textvar_pkg.MyTextValue",
-		IsPointer:         false,
-		IsTextUnmarshaler: true,
-		IsTextMarshaler:   true,
-		HelpText:          "Help for FieldA",
-		EnvVar:            "FIELD_A_ENV",
+		Name: "FieldA", CliName: "field-a", TypeName: "textvar_pkg.MyTextValue", IsTextUnmarshaler: true, IsTextMarshaler: true, HelpText: "Help for FieldA", EnvVar: "FIELD_A_ENV",
 	}
-
-	// Case 2: Pointer type *MyPtrTextValue (IsTextUnmarshaler=true, IsTextMarshaler=true)
 	optMetaPtr := &metadata.OptionMetadata{
-		Name:              "FieldB",
-		CliName:           "field-b",
-		TypeName:          "*textvar_pkg.MyPtrTextValue", // TypeName includes the star
-		IsPointer:         true,
-		IsTextUnmarshaler: true,
-		IsTextMarshaler:   true,
-		HelpText:          "Help for FieldB",
-		EnvVar:            "FIELD_B_ENV",
+		Name: "FieldB", CliName: "field-b", TypeName: "*textvar_pkg.MyPtrTextValue", IsPointer: true, IsTextUnmarshaler: true, IsTextMarshaler: true, HelpText: "Help for FieldB", EnvVar: "FIELD_B_ENV",
 	}
-
-	// Case 3: Only Unmarshaler (IsTextUnmarshaler=true, IsTextMarshaler=false)
-	// The current template for flag.TextVar requires both. This option should NOT use flag.TextVar.
-	// It should also not use the IsTextUnmarshaler block for env vars if that requires IsTextMarshaler too.
-	// For now, the template for EnvVar only checks .IsTextUnmarshaler.
 	optMetaOnlyUnmarshaler := &metadata.OptionMetadata{
-		Name:              "FieldF",
-		CliName:           "field-f",
-		TypeName:          "textvar_pkg.MyOnlyUnmarshaler",
-		IsPointer:         false,
-		IsTextUnmarshaler: true,
-		IsTextMarshaler:   false, // Explicitly false
-		HelpText:          "Help for FieldF - only unmarshaler",
-		EnvVar:            "FIELD_F_ENV",
+		Name: "FieldF", CliName: "field-f", TypeName: "textvar_pkg.MyOnlyUnmarshaler", IsTextUnmarshaler: true, IsTextMarshaler: false, HelpText: "Help for FieldF - only unmarshaler", EnvVar: "FIELD_F_ENV",
 	}
-
-
 	cmdMeta := &metadata.CommandMetadata{
-		RunFunc: runFuncInfo,
-		Options: []*metadata.OptionMetadata{optMetaValue, optMetaPtr, optMetaOnlyUnmarshaler},
+		RunFunc: runFuncInfo, Options: []*metadata.OptionMetadata{optMetaValue, optMetaPtr, optMetaOnlyUnmarshaler},
 	}
-
 	actualCode, err := GenerateMain(cmdMeta, "Test TextVar functionality", true)
 	if err != nil {
 		t.Fatalf("GenerateMain for TextVar options failed: %v", err)
 	}
-
-	// Assertions for Case 1 (Value type: textvar_pkg.MyTextValue)
-	expectedFlag_Case1 := `flag.TextVar(&options.FieldA, "field-a", options.FieldA, "Help for FieldA" /* Env: FIELD_A_ENV */)`
-	assertCodeContains(t, actualCode, expectedFlag_Case1)
-
-	// expectedEnv_Case1 := `
-	// if val, ok := os.LookupEnv("FIELD_A_ENV"); ok {
-	// 	if options.FieldA.IsTextUnmarshaler { //This is a slight misuse of the field, it should be a direct call
-	// 		err := (&options.FieldA).UnmarshalText([]byte(val))
-	// 		if err != nil {
-	// 			slog.Warn("Could not parse environment variable for TextUnmarshaler option; using default or previously set value.", "envVar", "FIELD_A_ENV", "option", "field-a", "value", val, "error", err)
-	// 		}
-    //     } else if eq options.FieldA.TypeName "string" {
-    //         // ... this structure is based on the template logic, the IsTextUnmarshaler should be a top-level if
-    //     }
-	// }`
-	// The above expectedEnv_Case1 is a bit complex due to how the template is structured.
-	// Let's simplify and check for the core UnmarshalText call.
-	simplifiedEnv_Case1_UnmarshalCall := `err := (&options.FieldA).UnmarshalText([]byte(val))`
-	assertCodeContains(t, actualCode, simplifiedEnv_Case1_UnmarshalCall)
+	assertCodeContains(t, actualCode, `flag.TextVar(&options.FieldA, "field-a", options.FieldA, "Help for FieldA" /* Env: FIELD_A_ENV */)`)
+	assertCodeContains(t, actualCode, `err := (&options.FieldA).UnmarshalText([]byte(val))`)
 	assertCodeContains(t, actualCode, `slog.Warn("Could not parse environment variable for TextUnmarshaler option; using default or previously set value.", "envVar", "FIELD_A_ENV", "option", "field-a"`)
-
-
-	// Assertions for Case 2 (Pointer type: *textvar_pkg.MyPtrTextValue)
-	// Note: CliName for FieldB will be "field-b" due to KebabCase in template if not specified in metadata's CliName
-	expectedFlag_Case2_Init := `if options.FieldB == nil { options.FieldB = new(textvar_pkg.MyPtrTextValue) }`
-	assertCodeContains(t, actualCode, expectedFlag_Case2_Init)
-	expectedFlag_Case2_Call := `flag.TextVar(options.FieldB, "field-b", options.FieldB, "Help for FieldB" /* Env: FIELD_B_ENV */)`
-	assertCodeContains(t, actualCode, expectedFlag_Case2_Call)
-
-	expectedEnv_Case2_Init := `
-		if options.FieldB == nil {
-			options.FieldB = new(textvar_pkg.MyPtrTextValue)
-		}`
-	assertCodeContains(t, actualCode, expectedEnv_Case2_Init)
-	expectedEnv_Case2_Call := `err := options.FieldB.UnmarshalText([]byte(val))`
-	assertCodeContains(t, actualCode, expectedEnv_Case2_Call)
+	assertCodeContains(t, actualCode, `if options.FieldB == nil { options.FieldB = new(textvar_pkg.MyPtrTextValue) }`)
+	assertCodeContains(t, actualCode, `flag.TextVar(options.FieldB, "field-b", options.FieldB, "Help for FieldB" /* Env: FIELD_B_ENV */)`)
+	assertCodeContains(t, actualCode, `if options.FieldB == nil { options.FieldB = new(textvar_pkg.MyPtrTextValue) }`)
+	assertCodeContains(t, actualCode, `err := options.FieldB.UnmarshalText([]byte(val))`)
 	assertCodeContains(t, actualCode, `slog.Warn("Could not parse environment variable for TextUnmarshaler option; using default or previously set value.", "envVar", "FIELD_B_ENV", "option", "field-b"`)
-
-	// Assertions for Case 3 (Only Unmarshaler: textvar_pkg.MyOnlyUnmarshaler)
-	// Should NOT use flag.TextVar because IsTextMarshaler is false.
-	// It might fall back to another flag type if we had more general fallback, or be skipped for flags.
-	// For now, let's assume it doesn't generate a flag.TextVar.
-	unexpectedFlag_Case3 := `flag.TextVar(&options.FieldF, "field-f"`
-	assertCodeNotContains(t, actualCode, unexpectedFlag_Case3)
-	unexpectedFlag_Case3_Ptr := `flag.TextVar(options.FieldF, "field-f"`
-    assertCodeNotContains(t, actualCode, unexpectedFlag_Case3_Ptr)
-
-
-	// Env var handling for FieldF (OnlyUnmarshaler) should still work as it only checks IsTextUnmarshaler
-	expectedEnv_Case3_Call := `err := (&options.FieldF).UnmarshalText([]byte(val))`
-	assertCodeContains(t, actualCode, expectedEnv_Case3_Call)
+	assertCodeNotContains(t, actualCode, `flag.TextVar(&options.FieldF, "field-f"`)
+	assertCodeNotContains(t, actualCode, `flag.TextVar(options.FieldF, "field-f"`)
+	assertCodeContains(t, actualCode, `err := (&options.FieldF).UnmarshalText([]byte(val))`)
 	assertCodeContains(t, actualCode, `slog.Warn("Could not parse environment variable for TextUnmarshaler option; using default or previously set value.", "envVar", "FIELD_F_ENV", "option", "field-f"`)
-
-	// General check for TrimStar usage in initialization for pointer types (already covered by Case 2 init check)
-	// Example: new(textvar_pkg.MyPtrTextValue) - TypeName for *MyPtrTextValue is "*textvar_pkg.MyPtrTextValue"
-	// TrimStar removes the leading "*" for the `new` call.
-	// So, `new({{.TypeName | TrimStar}})` becomes `new(textvar_pkg.MyPtrTextValue)`
-	assertCodeContains(t, actualCode, "new(textvar_pkg.MyPtrTextValue)") // From FieldB
+	assertCodeContains(t, actualCode, "new(textvar_pkg.MyPtrTextValue)")
 }
 
 func assertCodeNotContains(t *testing.T, actualGeneratedCode, unexpectedSnippet string) {
 	t.Helper()
 	normalizedActual := normalizeCode(t, actualGeneratedCode)
 	normalizedUnexpectedSnippet := normalizeForContains(unexpectedSnippet)
-
 	if strings.Contains(normalizedActual, normalizedUnexpectedSnippet) {
 		t.Errorf("Expected generated code NOT to contain (normalized):\n>>>>>>>>>>\n%s\n<<<<<<<<<<\n\nActual code (normalized):\n>>>>>>>>>>\n%s\n<<<<<<<<<<\n\nOriginal Unexpected Snippet:\n%s\n\nOriginal Actual Code:\n%s",
 			normalizedUnexpectedSnippet, normalizedActual, unexpectedSnippet, actualGeneratedCode)
@@ -192,21 +110,20 @@ func assertCodeNotContains(t *testing.T, actualGeneratedCode, unexpectedSnippet 
 
 func TestGenerateMain_BasicCase(t *testing.T) {
 	cmdMeta := &metadata.CommandMetadata{
+		Name: "github.com/podhmo/goat/cmd/goat",
 		RunFunc: &metadata.RunFuncInfo{
 			Name:                       "Run",
-			PackageName:                "mycmd",
+			PackageName:                "main",
 			OptionsArgTypeNameStripped: "OptionsType",
 			OptionsArgIsPointer:        true,
 		},
 		Options: []*metadata.OptionMetadata{},
 	}
-
 	actualCode, err := GenerateMain(cmdMeta, "", true)
 	if err != nil {
 		t.Fatalf("GenerateMain failed: %v", err)
 	}
-
-	assertCodeContains(t, actualCode, "err := Run()")
+	assertCodeContains(t, actualCode, "err = Run(options)")
 	assertCodeContains(t, actualCode, "func main() {")
 	assertCodeContains(t, actualCode, "if err != nil {")
 	assertCodeContains(t, actualCode, `slog.Error("Runtime error", "error", err)`)
@@ -216,9 +133,10 @@ func TestGenerateMain_BasicCase(t *testing.T) {
 
 func TestGenerateMain_WithOptions(t *testing.T) {
 	cmdMeta := &metadata.CommandMetadata{
+		Name: "anothercmd",
 		RunFunc: &metadata.RunFuncInfo{
 			Name:                       "RunWithOptions",
-			PackageName:                "anothercmd",
+			PackageName:                "main",
 			OptionsArgTypeNameStripped: "MyOptionsType",
 			OptionsArgIsPointer:        true,
 		},
@@ -228,23 +146,15 @@ func TestGenerateMain_WithOptions(t *testing.T) {
 			{Name: "Verbose", TypeName: "bool", HelpText: "Enable verbose output", DefaultValue: false},
 		},
 	}
-
 	actualCode, err := GenerateMain(cmdMeta, "", true)
 	if err != nil {
 		t.Fatalf("GenerateMain failed: %v", err)
 	}
-
 	assertCodeContains(t, actualCode, "var options *MyOptionsType")
 	assertCodeContains(t, actualCode, "options = new(MyOptionsType)")
-
-	// 1. Default values
 	assertCodeContains(t, actualCode, `options.Name = "guest"`)
 	assertCodeContains(t, actualCode, `options.Age = 30`)
 	assertCodeContains(t, actualCode, `options.Verbose = false`)
-
-	// 2. Env Var (not present in this test's metadata, so no specific env checks here)
-
-	// 3. Set Flags
 	expectedFlagParsing := `
 	flag.StringVar(&options.Name, "name", options.Name, "Name of the user" /* Original Default: guest, Env: */)
 	flag.IntVar(&options.Age, "age", options.Age, "Age of the user" /* Original Default: 30, Env: */)
@@ -252,7 +162,9 @@ func TestGenerateMain_WithOptions(t *testing.T) {
 	flag.Parse()
 `
 	assertCodeContains(t, actualCode, expectedFlagParsing)
-	assertCodeContains(t, actualCode, "err := RunWithOptions(options)")
+	assertCodeContains(t, actualCode, "err = RunWithOptions(options)")
+	assertCodeNotContains(t, actualCode, "import . \"anothercmd\"")
+	assertCodeNotContains(t, actualCode, "import \"anothercmd\"")
 }
 
 func TestGenerateMain_NoPackagePrefixWhenMain(t *testing.T) {
@@ -267,20 +179,13 @@ func TestGenerateMain_NoPackagePrefixWhenMain(t *testing.T) {
 			{Name: "Name", TypeName: "string", HelpText: "Name of the user", DefaultValue: "guest"},
 		},
 	}
-
 	actualCode, err := GenerateMain(cmdMeta, "", true)
 	if err != nil {
 		t.Fatalf("GenerateMain failed: %v", err)
 	}
-	// Should not have main.run() or main.Run(), just run()
-
-	// 1. Default value
 	assertCodeContains(t, actualCode, `options.Name = "guest"`)
-	// 2. Env Var (not in this test's metadata)
-	// 3. Set Flag
 	assertCodeContains(t, actualCode, `flag.StringVar(&options.Name, "name", options.Name, "Name of the user" /* Original Default: guest, Env: */)`)
-
-	assertCodeContains(t, actualCode, "err := run(options)")
+	assertCodeContains(t, actualCode, "err = run(options)")
 	assertCodeNotContains(t, actualCode, "main.run(")
 	assertCodeNotContains(t, actualCode, "main.Run(")
 }
@@ -289,7 +194,7 @@ func TestGenerateMain_KebabCaseFlagNames(t *testing.T) {
 	cmdMeta := &metadata.CommandMetadata{
 		RunFunc: &metadata.RunFuncInfo{
 			Name:                       "ProcessData",
-			PackageName:                "dataproc",
+			PackageName:                "main",
 			OptionsArgTypeNameStripped: "DataProcOptions",
 			OptionsArgIsPointer:        true,
 		},
@@ -299,23 +204,15 @@ func TestGenerateMain_KebabCaseFlagNames(t *testing.T) {
 			{Name: "MaximumRetries", TypeName: "int", HelpText: "Maximum number of retries", DefaultValue: 3},
 		},
 	}
-
-	actualCode, err := GenerateMain(cmdMeta, "", true) // Changed codegen.GenerateMain to GenerateMain
+	actualCode, err := GenerateMain(cmdMeta, "", true)
 	if err != nil {
 		t.Fatalf("GenerateMain failed: %v", err)
 	}
-
 	assertCodeContains(t, actualCode, "var options *DataProcOptions")
 	assertCodeContains(t, actualCode, "options = new(DataProcOptions)")
-
-	// 1. Default values
 	assertCodeContains(t, actualCode, `options.InputFile = ""`)
 	assertCodeContains(t, actualCode, `options.OutputDirectory = "/tmp"`)
 	assertCodeContains(t, actualCode, `options.MaximumRetries = 3`)
-
-	// 2. Env Var (not in this test's metadata)
-
-	// 3. Set Flags
 	expectedFlagParsing := `
 	flag.StringVar(&options.InputFile, "input-file", options.InputFile, "Input file path")
 	flag.StringVar(&options.OutputDirectory, "output-directory", options.OutputDirectory, "Output directory path" /* Original Default: /tmp, Env: */)
@@ -323,14 +220,14 @@ func TestGenerateMain_KebabCaseFlagNames(t *testing.T) {
 	flag.Parse()
 `
 	assertCodeContains(t, actualCode, expectedFlagParsing)
-	assertCodeContains(t, actualCode, "err := ProcessData(options)")
+	assertCodeContains(t, actualCode, "err = ProcessData(options)")
 }
 
 func TestGenerateMain_RequiredFlags(t *testing.T) {
 	cmdMeta := &metadata.CommandMetadata{
 		RunFunc: &metadata.RunFuncInfo{
 			Name:                       "DoSomething",
-			PackageName:                "task",
+			PackageName:                "main",
 			OptionsArgTypeNameStripped: "Config",
 			OptionsArgIsPointer:        false,
 		},
@@ -339,72 +236,34 @@ func TestGenerateMain_RequiredFlags(t *testing.T) {
 			{Name: "Retries", TypeName: "int", HelpText: "Number of retries", IsRequired: true, DefaultValue: 0},
 		},
 	}
-
-	actualCode, err := GenerateMain(cmdMeta, "", true) // Changed codegen.GenerateMain to GenerateMain
+	actualCode, err := GenerateMain(cmdMeta, "", true)
 	if err != nil {
 		t.Fatalf("GenerateMain failed: %v", err)
 	}
-
 	assertCodeContains(t, actualCode, "var options *Config")
 	assertCodeContains(t, actualCode, "options = new(Config)")
-
-	// 1. Default values
 	assertCodeContains(t, actualCode, `options.ConfigFile = ""`)
 	assertCodeContains(t, actualCode, `options.Retries = 0`)
-
-	// 2. Env Var (not in this test's metadata)
-	// Ensure no env var logic is generated for these specific options
-	assertCodeNotContains(t, actualCode, `os.LookupEnv("CONFIG_FILE")`) // Assuming no EnvVar named "CONFIG_FILE"
-	assertCodeNotContains(t, actualCode, `os.LookupEnv("RETRIES")`)   // Assuming no EnvVar named "RETRIES"
-
-	// 3. Set Flags
+	assertCodeNotContains(t, actualCode, `os.LookupEnv("CONFIG_FILE")`)
+	assertCodeNotContains(t, actualCode, `os.LookupEnv("RETRIES")`)
 	assertCodeContains(t, actualCode, `flag.StringVar(&options.ConfigFile, "config-file", options.ConfigFile, "Path to config file")`)
 	assertCodeContains(t, actualCode, `flag.IntVar(&options.Retries, "retries", options.Retries, "Number of retries" /* Original Default: 0, Env: */)`)
-
-	// 4. Required Checks
-	// expectedConfigFileCheck := `
-	// initialDefaultConfigFile := ""
-	// envConfigFileWasSet := false
-	// if _, ok := os.LookupEnv(""); ok { envConfigFileWasSet = true } // This check is generic; for "" it's effectively false unless an empty env var name is somehow set
-	// if options.ConfigFile == initialDefaultConfigFile && !isFlagExplicitlySet["config-file"] && !envConfigFileWasSet {
-	// 	slog.Error("Missing required flag or environment variable not set", "flag", "config-file", "option", "ConfigFile")
-	// 	os.Exit(1)
-	// }
-// `
-	// We need to adjust the env var check slightly for the test assertion as "" is used when no env var is specified.
-	// The generated code for `envConfigFileWasSet` will be `if _, ok := os.LookupEnv(""); ok { envConfigFileWasSet = true }`
-	// which is fine, it will evaluate to false if "" is not a set env var.
-	// For the assertion, we'll look for the key parts.
 	assertCodeContains(t, actualCode, `initialDefaultConfigFile := ""`)
 	assertCodeContains(t, actualCode, `envConfigFileWasSet := false`)
-	// The actual env check for ConfigFile will be against "" since {{.EnvVar}} is empty.
-	// assertCodeContains(t, actualCode, `if _, ok := os.LookupEnv(""); ok { envConfigFileWasSet = true }`)
 	assertCodeContains(t, actualCode, `if options.ConfigFile == initialDefaultConfigFile && !isFlagExplicitlySet["config-file"] && !envConfigFileWasSet {`)
 	assertCodeContains(t, actualCode, `slog.Error("Missing required flag or environment variable not set", "flag", "config-file", "option", "ConfigFile")`)
-
-	// expectedRetriesCheck := `
-	// initialDefaultRetries := 0
-	// envRetriesWasSet := false
-	// if _, ok := os.LookupEnv(""); ok { envRetriesWasSet = true } // Generic check for no EnvVar
-	// if options.Retries == initialDefaultRetries && !isFlagExplicitlySet["retries"] && !envRetriesWasSet {
-	// 	slog.Error("Missing required flag or environment variable not set", "flag", "retries", "option", "Retries")
-	// 	os.Exit(1)
-	// }
-// `
 	assertCodeContains(t, actualCode, `initialDefaultRetries := 0`)
 	assertCodeContains(t, actualCode, `envRetriesWasSet := false`)
-	// assertCodeContains(t, actualCode, `if _, ok := os.LookupEnv(""); ok { envRetriesWasSet = true }`) // Check for Retries env var (which is empty)
 	assertCodeContains(t, actualCode, `if options.Retries == initialDefaultRetries && !isFlagExplicitlySet["retries"] && !envRetriesWasSet {`)
 	assertCodeContains(t, actualCode, `slog.Error("Missing required flag or environment variable not set", "flag", "retries", "option", "Retries")`)
-
-	assertCodeContains(t, actualCode, "err := DoSomething(*options)")
+	assertCodeContains(t, actualCode, "err = DoSomething(*options)")
 }
 
 func TestGenerateMain_EnumValidation(t *testing.T) {
 	cmdMeta := &metadata.CommandMetadata{
 		RunFunc: &metadata.RunFuncInfo{
 			Name:                       "SetMode",
-			PackageName:                "control",
+			PackageName:                "main",
 			OptionsArgTypeNameStripped: "ModeOptions",
 			OptionsArgIsPointer:        true,
 		},
@@ -412,25 +271,15 @@ func TestGenerateMain_EnumValidation(t *testing.T) {
 			{Name: "Mode", TypeName: "string", HelpText: "Mode of operation", EnumValues: []any{"auto", "manual", "standby"}, DefaultValue: "auto"},
 		},
 	}
-
 	actualCode, err := GenerateMain(cmdMeta, "", true)
 	if err != nil {
 		t.Fatalf("GenerateMain failed: %v", err)
 	}
-
 	assertCodeContains(t, actualCode, "var options *ModeOptions")
 	assertCodeContains(t, actualCode, "options = new(ModeOptions)")
-
-	// 1. Default value
 	assertCodeContains(t, actualCode, `options.Mode = "auto"`)
-
-	// 2. Env Var (not in this test's metadata)
-	assertCodeNotContains(t, actualCode, `os.LookupEnv("MODE")`) // Assuming no EnvVar "MODE"
-
-	// 3. Set Flag
+	assertCodeNotContains(t, actualCode, `os.LookupEnv("MODE")`)
 	assertCodeContains(t, actualCode, `flag.StringVar(&options.Mode, "mode", options.Mode, "Mode of operation" /* Original Default: auto, Env: */)`)
-
-	// 4. Enum Validation (should largely be the same)
 	expectedEnumValidation := `
 	isValidChoice_Mode := false
 	allowedChoices_Mode := []string{"auto", "manual", "standby"}
@@ -444,14 +293,14 @@ func TestGenerateMain_EnumValidation(t *testing.T) {
 	}
 `
 	assertCodeContains(t, actualCode, expectedEnumValidation)
-	assertCodeContains(t, actualCode, "err := SetMode(options)") // TODO: control.SetMode(options)
+	assertCodeContains(t, actualCode, "err = SetMode(options)")
 }
 
 func TestGenerateMain_EnvironmentVariables(t *testing.T) {
 	cmdMeta := &metadata.CommandMetadata{
 		RunFunc: &metadata.RunFuncInfo{
 			Name:                       "Configure",
-			PackageName:                "setup",
+			PackageName:                "main",
 			OptionsArgTypeNameStripped: "AppSettings",
 			OptionsArgIsPointer:        true,
 		},
@@ -461,28 +310,21 @@ func TestGenerateMain_EnvironmentVariables(t *testing.T) {
 			{Name: "EnableFeature", TypeName: "bool", HelpText: "Enable new feature", DefaultValue: false, EnvVar: "ENABLE_MY_FEATURE"},
 		},
 	}
-
 	actualCode, err := GenerateMain(cmdMeta, "", true)
 	if err != nil {
 		t.Fatalf("GenerateMain failed: %v", err)
 	}
-
 	assertCodeContains(t, actualCode, "var options *AppSettings")
 	assertCodeContains(t, actualCode, "options = new(AppSettings)")
-
-	// 1. Default values
 	assertCodeContains(t, actualCode, `options.APIKey = ""`)
 	assertCodeContains(t, actualCode, `options.Timeout = 60`)
 	assertCodeContains(t, actualCode, `options.EnableFeature = false`)
-
-	// 2. Env Var Overrides
 	expectedApiKeyEnv := `
 	if val, ok := os.LookupEnv("API_KEY"); ok {
 		options.APIKey = val
 	}
 `
 	assertCodeContains(t, actualCode, expectedApiKeyEnv)
-
 	expectedTimeoutEnv := `
 	if val, ok := os.LookupEnv("TIMEOUT_SECONDS"); ok {
 		if v, err := strconv.Atoi(val); err == nil {
@@ -493,7 +335,6 @@ func TestGenerateMain_EnvironmentVariables(t *testing.T) {
 	}
 `
 	assertCodeContains(t, actualCode, expectedTimeoutEnv)
-
 	expectedEnableFeatureEnv := `
 	if val, ok := os.LookupEnv("ENABLE_MY_FEATURE"); ok {
 		if v, err := strconv.ParseBool(val); err == nil {
@@ -504,20 +345,17 @@ func TestGenerateMain_EnvironmentVariables(t *testing.T) {
 	}
 `
 	assertCodeContains(t, actualCode, expectedEnableFeatureEnv)
-
-	// 3. Set Flags
 	assertCodeContains(t, actualCode, `flag.StringVar(&options.APIKey, "api-key", options.APIKey, "API Key" /* Env: API_KEY */)`)
 	assertCodeContains(t, actualCode, `flag.IntVar(&options.Timeout, "timeout", options.Timeout, "Timeout in seconds" /* Original Default: 60, Env: TIMEOUT_SECONDS */)`)
 	assertCodeContains(t, actualCode, `flag.BoolVar(&options.EnableFeature, "enable-feature", options.EnableFeature, "Enable new feature" /* Original Default: false, Env: ENABLE_MY_FEATURE */)`)
-
-	assertCodeContains(t, actualCode, "err := Configure(options)")
+	assertCodeContains(t, actualCode, "err = Configure(options)")
 }
 
 func TestGenerateMain_EnvVarForBoolWithTrueDefault(t *testing.T) {
 	cmdMeta := &metadata.CommandMetadata{
 		RunFunc: &metadata.RunFuncInfo{
 			Name:                       "ProcessWithFeature",
-			PackageName:                "featureproc",
+			PackageName:                "main",
 			OptionsArgTypeNameStripped: "FeatureOptions",
 			OptionsArgIsPointer:        true,
 		},
@@ -525,19 +363,13 @@ func TestGenerateMain_EnvVarForBoolWithTrueDefault(t *testing.T) {
 			{Name: "SmartParsing", TypeName: "bool", HelpText: "Enable smart parsing", DefaultValue: true, EnvVar: "SMART_PARSING_ENABLED"},
 		},
 	}
-
 	actualCode, err := GenerateMain(cmdMeta, "", true)
 	if err != nil {
 		t.Fatalf("GenerateMain failed: %v", err)
 	}
-
 	assertCodeContains(t, actualCode, "var options *FeatureOptions")
 	assertCodeContains(t, actualCode, "options = new(FeatureOptions)")
-
-	// 1. Default value
 	assertCodeContains(t, actualCode, `options.SmartParsing = true`)
-
-	// 2. Env Var Override
 	expectedEnvLogic := `
 	if val, ok := os.LookupEnv("SMART_PARSING_ENABLED"); ok {
 		if v, err := strconv.ParseBool(val); err == nil {
@@ -548,18 +380,15 @@ func TestGenerateMain_EnvVarForBoolWithTrueDefault(t *testing.T) {
 	}
 `
 	assertCodeContains(t, actualCode, expectedEnvLogic)
-
-	// 3. Set Flag
 	assertCodeContains(t, actualCode, `flag.BoolVar(&options.SmartParsing, "smart-parsing", options.SmartParsing, "Enable smart parsing" /* Original Default: true, Env: SMART_PARSING_ENABLED */)`)
-
-	assertCodeContains(t, actualCode, "err := ProcessWithFeature(options)")
+	assertCodeContains(t, actualCode, "err = ProcessWithFeature(options)")
 }
 
 func TestGenerateMain_RequiredBool_DefaultFalse(t *testing.T) {
 	cmdMeta := &metadata.CommandMetadata{
 		RunFunc: &metadata.RunFuncInfo{
 			Name:                       "ProcessData",
-			PackageName:                "dataproc",
+			PackageName:                "main",
 			OptionsArgTypeNameStripped: "DataOptions",
 			OptionsArgIsPointer:        true,
 		},
@@ -567,38 +396,25 @@ func TestGenerateMain_RequiredBool_DefaultFalse(t *testing.T) {
 			{Name: "ForceOverwrite", TypeName: "bool", HelpText: "Force overwrite of existing files", IsRequired: true, DefaultValue: false},
 		},
 	}
-
 	actualCode, err := GenerateMain(cmdMeta, "", true)
 	if err != nil {
 		t.Fatalf("GenerateMain failed: %v", err)
 	}
-
 	assertCodeContains(t, actualCode, "var options *DataOptions")
 	assertCodeContains(t, actualCode, "options = new(DataOptions)")
-
-	// 1. Default value
 	assertCodeContains(t, actualCode, `options.ForceOverwrite = false`)
-
-	// 2. Env Var (not in this test's metadata)
 	assertCodeNotContains(t, actualCode, `os.LookupEnv("FORCE_OVERWRITE")`)
-
-	// 3. Set Flag
-	// Standard bool flag, defaults to false.
-	// IsRequired=true for a bool defaulting to false implies the action is off by default and needs the flag to turn on.
-	// The generator doesn't add a specific "missing" check for this, as "missing" means "false", which is the default.
 	expectedFlagParsing := `flag.BoolVar(&options.ForceOverwrite, "force-overwrite", options.ForceOverwrite, "Force overwrite of existing files" /* Original Default: false, Env: */)`
 	assertCodeContains(t, actualCode, expectedFlagParsing)
-
-	// There should NOT be the special "no-" prefix logic for this case.
 	assertCodeNotContains(t, actualCode, "var ForceOverwrite_NoFlagIsPresent bool")
-	assertCodeNotContains(t, actualCode, "options.ForceOverwrite = true") // Should not default to true in post-parse
+	assertCodeNotContains(t, actualCode, "options.ForceOverwrite = true")
 }
 
 func TestGenerateMain_RequiredBool_DefaultTrue(t *testing.T) {
 	cmdMeta := &metadata.CommandMetadata{
 		RunFunc: &metadata.RunFuncInfo{
 			Name:                       "RunTask",
-			PackageName:                "taskrunner",
+			PackageName:                "main",
 			OptionsArgTypeNameStripped: "TaskConfig",
 			OptionsArgIsPointer:        true,
 		},
@@ -606,48 +422,28 @@ func TestGenerateMain_RequiredBool_DefaultTrue(t *testing.T) {
 			{Name: "EnableSync", TypeName: "bool", HelpText: "Enable synchronization", IsRequired: true, DefaultValue: true},
 		},
 	}
-
 	actualCode, err := GenerateMain(cmdMeta, "", true)
 	if err != nil {
 		t.Fatalf("GenerateMain failed: %v", err)
 	}
-
 	assertCodeContains(t, actualCode, "var options *TaskConfig")
 	assertCodeContains(t, actualCode, "options = new(TaskConfig)")
-
-	// 1. Default value
 	assertCodeContains(t, actualCode, `options.EnableSync = true`)
-
-	// 2. Env Var (not in this test's metadata)
 	assertCodeNotContains(t, actualCode, `os.LookupEnv("ENABLE_SYNC")`)
-
-	// 3. Set Flag (special 'no-' case for required bool defaulting to true)
-	// The options.EnableSync is already true (from default or env).
-	// We define a 'no-' flag to allow setting it to false.
 	expectedFlagDefinition := `
 	var EnableSync_NoFlagIsPresent bool
 	flag.BoolVar(&EnableSync_NoFlagIsPresent, "no-enable-sync", false, "Set enable-sync to false")
 `
 	assertCodeContains(t, actualCode, expectedFlagDefinition)
-
-	// 4. Post-parse logic to update options.EnableSync if 'no-' flag was set
-	// options.EnableSync remains true unless EnableSync_NoFlagIsPresent is true.
 	expectedPostParseLogic := `
 	if EnableSync_NoFlagIsPresent {
 		options.EnableSync = false
 	}
 `
 	assertCodeContains(t, actualCode, expectedPostParseLogic)
-	// Ensure the initial options.EnableSync = true from defaults is NOT within the post-parse logic block itself directly.
-	// It should be set earlier. The post-parse only potentially flips it to false.
 	assertCodeNotContains(t, actualCode, "if EnableSync_NoFlagIsPresent { options.EnableSync = false } else { options.EnableSync = true }")
-
-
-	// Should NOT use the direct flag name for the flag variable or default to false in flag.BoolVar for options.EnableSync
 	assertCodeNotContains(t, actualCode, `flag.BoolVar(&options.EnableSync, "enable-sync"`)
-	assertCodeNotContains(t, actualCode, `flag.BoolVar(&options.EnableSync, "no-enable-sync"`) // temporary var is used
-
-	// Should NOT generate a "Missing required flag" check for this type of boolean flag
+	assertCodeNotContains(t, actualCode, `flag.BoolVar(&options.EnableSync, "no-enable-sync"`)
 	assertCodeNotContains(t, actualCode, `slog.Error("Missing required flag", "flag", "no-enable-sync")`)
 	assertCodeNotContains(t, actualCode, `slog.Error("Missing required flag", "flag", "enable-sync")`)
 }
@@ -656,12 +452,12 @@ func TestGenerateMain_ErrorHandling(t *testing.T) {
 	cmdMeta := &metadata.CommandMetadata{
 		RunFunc: &metadata.RunFuncInfo{
 			Name:                       "DefaultRun",
-			PackageName:                "pkg",
+			PackageName:                "main",
 			OptionsArgTypeNameStripped: "Irrelevant",
 			OptionsArgIsPointer:        true,
 		},
 	}
-	actualCode, err := GenerateMain(cmdMeta, "", true) // Changed codegen.GenerateMain to GenerateMain
+	actualCode, err := GenerateMain(cmdMeta, "", true)
 	if err != nil {
 		t.Fatalf("GenerateMain failed: %v", err)
 	}
@@ -678,7 +474,7 @@ func TestGenerateMain_Imports(t *testing.T) {
 	cmdMetaNoStrconv := &metadata.CommandMetadata{
 		RunFunc: &metadata.RunFuncInfo{
 			Name:                       "MyFunc",
-			PackageName:                "custompkg",
+			PackageName:                "main",
 			OptionsArgTypeNameStripped: "AppConfig",
 			OptionsArgIsPointer:        true,
 		},
@@ -686,7 +482,7 @@ func TestGenerateMain_Imports(t *testing.T) {
 			{Name: "Name", TypeName: "string", EnvVar: "APP_NAME", HelpText: "app name"},
 		},
 	}
-	actualCodeNoStrconv, err := GenerateMain(cmdMetaNoStrconv, "", true) // Changed codegen.GenerateMain to GenerateMain
+	actualCodeNoStrconv, err := GenerateMain(cmdMetaNoStrconv, "", true)
 	if err != nil {
 		t.Fatalf("GenerateMain failed: %v", err)
 	}
@@ -696,7 +492,7 @@ func TestGenerateMain_Imports(t *testing.T) {
 	cmdMetaWithStrconv := &metadata.CommandMetadata{
 		RunFunc: &metadata.RunFuncInfo{
 			Name:                       "MyOtherFunc",
-			PackageName:                "custompkg",
+			PackageName:                "main",
 			OptionsArgTypeNameStripped: "ServerConfig",
 			OptionsArgIsPointer:        false,
 		},
@@ -704,7 +500,7 @@ func TestGenerateMain_Imports(t *testing.T) {
 			{Name: "Port", TypeName: "int", EnvVar: "APP_PORT", HelpText: "app port"},
 		},
 	}
-	actualCodeWithStrconv, err := GenerateMain(cmdMetaWithStrconv, "", true) // Changed codegen.GenerateMain to GenerateMain
+	actualCodeWithStrconv, err := GenerateMain(cmdMetaWithStrconv, "", true)
 	if err != nil {
 		t.Fatalf("GenerateMain failed: %v", err)
 	}
@@ -716,7 +512,7 @@ func TestGenerateMain_RequiredIntWithEnvVar(t *testing.T) {
 	cmdMeta := &metadata.CommandMetadata{
 		RunFunc: &metadata.RunFuncInfo{
 			Name:                       "SubmitData",
-			PackageName:                "submitter",
+			PackageName:                "main",
 			OptionsArgTypeNameStripped: "UserData",
 			OptionsArgIsPointer:        true,
 		},
@@ -725,28 +521,15 @@ func TestGenerateMain_RequiredIntWithEnvVar(t *testing.T) {
 		},
 	}
 
-	actualCode, err := GenerateMain(cmdMeta, "", true) // Changed codegen.GenerateMain to GenerateMain
+	actualCode, err := GenerateMain(cmdMeta, "", true)
 	if err != nil {
 		t.Fatalf("GenerateMain failed: %v", err)
 	}
-
 	assertCodeContains(t, actualCode, "var options *UserData")
 	assertCodeContains(t, actualCode, "options = new(UserData)")
-
-	// 1. Default value
 	assertCodeContains(t, actualCode, `options.UserId = 0`)
-
-	// 2. Env Var Override
 	assertCodeContains(t, actualCode, `if val, ok := os.LookupEnv("USER_ID"); ok { if v, err := strconv.Atoi(val); err == nil { options.UserId = v } else { slog.Warn("Could not parse environment variable as int for option", "envVar", "USER_ID", "option", "UserId", "value", val, "error", err) } }`)
-
-	// 3. Set Flag
 	assertCodeContains(t, actualCode, `flag.IntVar(&options.UserId, "user-id", options.UserId, "User ID" /* Original Default: 0, Env: USER_ID */)`)
-
-	// 4. Required Check
-	// This check ensures that if the value is still the initial default (0),
-	// and the flag wasn't set, and the env var also wasn't set (or failed to parse), then it's an error.
-	// The test name implies the env var is intended to be the provider.
-	// If USER_ID is set, envUserIdWasSet becomes true, and the error condition options.UserId == initialDefaultUserId && !isFlagExplicitlySet["user-id"] && !envUserIdWasSet is false.
 	expectedRequiredCheck := `
 	initialDefaultUserId := 0
 	envUserIdWasSet := false
@@ -757,22 +540,14 @@ func TestGenerateMain_RequiredIntWithEnvVar(t *testing.T) {
 	}
 `
 	assertCodeContains(t, actualCode, expectedRequiredCheck)
-	// Given the required check, if the env var is NOT set and the flag is NOT set, it WILL error.
-	// The original test asserted assertCodeNotContains for the error. This remains correct under the assumption
-	// that the test case implies USER_ID env var is successfully set and parsed, making `envUserIdWasSet` true,
-	// thus bypassing the error.
-	// The assertion below is a bit indirect; it's checking that the *specific* error message isn't there.
-	// A more direct test would involve simulating flag/env states and checking options values and exit codes.
-	// For now, verifying the generated code structure is the goal.
-
-	assertCodeContains(t, actualCode, "err := SubmitData(options)")
+	assertCodeContains(t, actualCode, "err = SubmitData(options)")
 }
 
 func TestGenerateMain_EnvVarPrecendenceStrategy(t *testing.T) {
 	cmdMeta := &metadata.CommandMetadata{
 		RunFunc: &metadata.RunFuncInfo{
 			Name:                       "RunStrategyTest",
-			PackageName:                "strategy",
+			PackageName:                "main",
 			OptionsArgTypeNameStripped: "StrategyOptions",
 			OptionsArgIsPointer:        true,
 		},
@@ -791,54 +566,38 @@ func TestGenerateMain_EnvVarPrecendenceStrategy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateMain failed: %v", err)
 	}
-
-	// 1. Assertions for isFlagExplicitlySet and flag.Visit
 	assertCodeContains(t, actualCode, `isFlagExplicitlySet := make(map[string]bool)`)
 	assertCodeContains(t, actualCode, `flag.Visit(func(f *flag.Flag) { isFlagExplicitlySet[f.Name] = true })`)
-
-	// 2. Assertions for Non-Pointer Types
-	// StringOpt
-	assertCodeContains(t, actualCode, `options.StringOpt = "original_string"`) // 1. Default value
-	assertCodeContains(t, actualCode, `if val, ok := os.LookupEnv("ENV_STRING"); ok { options.StringOpt = val }`) // 2. Env override
-	assertCodeContains(t, actualCode, `flag.StringVar(&options.StringOpt, "string-opt", options.StringOpt, "String option" /* Original Default: original_string, Env: ENV_STRING */)`) // 3. Set flag
-
-	// IntOpt
-	assertCodeContains(t, actualCode, `options.IntOpt = 123`) // 1. Default value
-	assertCodeContains(t, actualCode, `if val, ok := os.LookupEnv("ENV_INT"); ok { if v, err := strconv.Atoi(val); err == nil { options.IntOpt = v } else { slog.Warn("Could not parse environment variable as int for option", "envVar", "ENV_INT", "option", "IntOpt", "value", val, "error", err) } }`) // 2. Env override
-	assertCodeContains(t, actualCode, `flag.IntVar(&options.IntOpt, "int-opt", options.IntOpt, "Int option" /* Original Default: 123, Env: ENV_INT */)`) // 3. Set flag
-
-	// BoolOpt
-	assertCodeContains(t, actualCode, `options.BoolOpt = false`) // 1. Default value
-	assertCodeContains(t, actualCode, `if val, ok := os.LookupEnv("ENV_BOOL"); ok { if v, err := strconv.ParseBool(val); err == nil { options.BoolOpt = v } else { slog.Warn("Could not parse environment variable as bool for option", "envVar", "ENV_BOOL", "option", "BoolOpt", "value", val, "error", err) } }`) // 2. Env override
-	assertCodeContains(t, actualCode, `flag.BoolVar(&options.BoolOpt, "bool-opt", options.BoolOpt, "Bool option" /* Original Default: false, Env: ENV_BOOL */)`) // 3. Set flag
-
-	// BoolTrueOpt (special no- flag case)
-	assertCodeContains(t, actualCode, `options.BoolTrueOpt = true`) // 1. Default value
-	assertCodeContains(t, actualCode, `if val, ok := os.LookupEnv("ENV_BOOL_TRUE"); ok { if v, err := strconv.ParseBool(val); err == nil { options.BoolTrueOpt = v } else { slog.Warn("Could not parse environment variable as bool for option", "envVar", "ENV_BOOL_TRUE", "option", "BoolTrueOpt", "value", val, "error", err) } }`) // 2. Env override
-	assertCodeContains(t, actualCode, `var BoolTrueOpt_NoFlagIsPresent bool`) // 3. Set flag (part 1)
-	assertCodeContains(t, actualCode, `flag.BoolVar(&BoolTrueOpt_NoFlagIsPresent, "no-bool-true-opt", false, "Set bool-true-opt to false")`) // 3. Set flag (part 2)
-	assertCodeContains(t, actualCode, `if BoolTrueOpt_NoFlagIsPresent { options.BoolTrueOpt = false }`) // 4. Parse (post-parse)
-
-	// 3. Assertions for Pointer Types
-	// StringPtrOpt
-	assertCodeContains(t, actualCode, `options.StringPtrOpt = new(string)`) // 1. Default (init pointer)
+	assertCodeContains(t, actualCode, `options.StringOpt = "original_string"`)
+	assertCodeContains(t, actualCode, `if val, ok := os.LookupEnv("ENV_STRING"); ok { options.StringOpt = val }`)
+	assertCodeContains(t, actualCode, `flag.StringVar(&options.StringOpt, "string-opt", options.StringOpt, "String option" /* Original Default: original_string, Env: ENV_STRING */)`)
+	assertCodeContains(t, actualCode, `options.IntOpt = 123`)
+	assertCodeContains(t, actualCode, `if val, ok := os.LookupEnv("ENV_INT"); ok { if v, err := strconv.Atoi(val); err == nil { options.IntOpt = v } else { slog.Warn("Could not parse environment variable as int for option", "envVar", "ENV_INT", "option", "IntOpt", "value", val, "error", err) } }`)
+	assertCodeContains(t, actualCode, `flag.IntVar(&options.IntOpt, "int-opt", options.IntOpt, "Int option" /* Original Default: 123, Env: ENV_INT */)`)
+	assertCodeContains(t, actualCode, `options.BoolOpt = false`)
+	assertCodeContains(t, actualCode, `if val, ok := os.LookupEnv("ENV_BOOL"); ok { if v, err := strconv.ParseBool(val); err == nil { options.BoolOpt = v } else { slog.Warn("Could not parse environment variable as bool for option", "envVar", "ENV_BOOL", "option", "BoolOpt", "value", val, "error", err) } }`)
+	assertCodeContains(t, actualCode, `flag.BoolVar(&options.BoolOpt, "bool-opt", options.BoolOpt, "Bool option" /* Original Default: false, Env: ENV_BOOL */)`)
+	assertCodeContains(t, actualCode, `options.BoolTrueOpt = true`)
+	assertCodeContains(t, actualCode, `if val, ok := os.LookupEnv("ENV_BOOL_TRUE"); ok { if v, err := strconv.ParseBool(val); err == nil { options.BoolTrueOpt = v } else { slog.Warn("Could not parse environment variable as bool for option", "envVar", "ENV_BOOL_TRUE", "option", "BoolTrueOpt", "value", val, "error", err) } }`)
+	assertCodeContains(t, actualCode, `var BoolTrueOpt_NoFlagIsPresent bool`)
+	assertCodeContains(t, actualCode, `flag.BoolVar(&BoolTrueOpt_NoFlagIsPresent, "no-bool-true-opt", false, "Set bool-true-opt to false")`)
+	assertCodeContains(t, actualCode, `if BoolTrueOpt_NoFlagIsPresent { options.BoolTrueOpt = false }`)
+	assertCodeContains(t, actualCode, `options.StringPtrOpt = new(string)`)
 	stringPtrEnvLogic := `
 	if val, ok := os.LookupEnv("ENV_STRING_PTR"); ok {
 		if options.StringPtrOpt == nil { options.StringPtrOpt = new(string) }
 		*options.StringPtrOpt = val
 	}
 `
-	assertCodeContains(t, actualCode, stringPtrEnvLogic) // 2. Env override
+	assertCodeContains(t, actualCode, stringPtrEnvLogic)
 	stringPtrFlagLogic := `
 	var defaultStringPtrOptValForFlag string
 	if options.StringPtrOpt != nil { defaultStringPtrOptValForFlag = *options.StringPtrOpt }
 	if options.StringPtrOpt == nil { options.StringPtrOpt = new(string) }
 	flag.StringVar(options.StringPtrOpt, "string-ptr-opt", defaultStringPtrOptValForFlag, "String pointer option" /* Env: ENV_STRING_PTR */)
 `
-	assertCodeContains(t, actualCode, stringPtrFlagLogic) // 3. Set flag
-
-	// IntPtrOpt
-	assertCodeContains(t, actualCode, `options.IntPtrOpt = new(int)`) // 1. Default (init pointer)
+	assertCodeContains(t, actualCode, stringPtrFlagLogic)
+	assertCodeContains(t, actualCode, `options.IntPtrOpt = new(int)`)
 	intPtrEnvLogic := `
 	if val, ok := os.LookupEnv("ENV_INT_PTR"); ok {
 		if options.IntPtrOpt == nil { options.IntPtrOpt = new(int) }
@@ -849,17 +608,15 @@ func TestGenerateMain_EnvVarPrecendenceStrategy(t *testing.T) {
 		}
 	}
 `
-	assertCodeContains(t, actualCode, intPtrEnvLogic) // 2. Env override
+	assertCodeContains(t, actualCode, intPtrEnvLogic)
 	intPtrFlagLogic := `
 	var defaultIntPtrOptValForFlag int
 	if options.IntPtrOpt != nil { defaultIntPtrOptValForFlag = *options.IntPtrOpt }
 	if options.IntPtrOpt == nil { options.IntPtrOpt = new(int) }
 	flag.IntVar(options.IntPtrOpt, "int-ptr-opt", defaultIntPtrOptValForFlag, "Int pointer option" /* Env: ENV_INT_PTR */)
 `
-	assertCodeContains(t, actualCode, intPtrFlagLogic) // 3. Set flag
-
-	// BoolPtrOpt
-	assertCodeContains(t, actualCode, `options.BoolPtrOpt = new(bool)`) // 1. Default (init pointer)
+	assertCodeContains(t, actualCode, intPtrFlagLogic)
+	assertCodeContains(t, actualCode, `options.BoolPtrOpt = new(bool)`)
 	boolPtrEnvLogic := `
 	if val, ok := os.LookupEnv("ENV_BOOL_PTR"); ok {
 		if options.BoolPtrOpt == nil { options.BoolPtrOpt = new(bool) }
@@ -870,25 +627,23 @@ func TestGenerateMain_EnvVarPrecendenceStrategy(t *testing.T) {
 		}
 	}
 `
-	assertCodeContains(t, actualCode, boolPtrEnvLogic) // 2. Env override
+	assertCodeContains(t, actualCode, boolPtrEnvLogic)
 	boolPtrFlagLogic := `
 	var defaultBoolPtrOptValForFlag bool
 	if options.BoolPtrOpt != nil { defaultBoolPtrOptValForFlag = *options.BoolPtrOpt }
 	if options.BoolPtrOpt == nil { options.BoolPtrOpt = new(bool) }
 	flag.BoolVar(options.BoolPtrOpt, "bool-ptr-opt", defaultBoolPtrOptValForFlag, "Bool pointer option" /* Env: ENV_BOOL_PTR */)
 `
-	assertCodeContains(t, actualCode, boolPtrFlagLogic) // 3. Set flag
-
-	// 4. Assertion for absence of old logic (example using defaultXXX vars)
+	assertCodeContains(t, actualCode, boolPtrFlagLogic)
 	assertCodeNotContains(t, actualCode, `var defaultStringOpt string =`)
-	assertCodeNotContains(t, actualCode, `if !isFlagExplicitlySet["string-ptr-opt"] { if val, ok := os.LookupEnv("ENV_STRING_PTR"); ok {`) // old location of env var check for pointers
+	assertCodeNotContains(t, actualCode, `if !isFlagExplicitlySet["string-ptr-opt"] { if val, ok := os.LookupEnv("ENV_STRING_PTR"); ok {`)
 }
 
 func TestGenerateMain_StringFlagWithQuotesInDefault(t *testing.T) {
 	cmdMeta := &metadata.CommandMetadata{
 		RunFunc: &metadata.RunFuncInfo{
 			Name:                       "PrintString",
-			PackageName:                "printer",
+			PackageName:                "main",
 			OptionsArgTypeNameStripped: "PrintOpts",
 			OptionsArgIsPointer:        true,
 		},
@@ -896,18 +651,13 @@ func TestGenerateMain_StringFlagWithQuotesInDefault(t *testing.T) {
 			{Name: "Greeting", TypeName: "string", HelpText: "A greeting message", DefaultValue: `hello "world"`},
 		},
 	}
-	actualCode, err := GenerateMain(cmdMeta, "", true) // Changed codegen.GenerateMain to GenerateMain
+	actualCode, err := GenerateMain(cmdMeta, "", true)
 	if err != nil {
 		t.Fatalf("GenerateMain failed: %v", err)
 	}
-
 	assertCodeContains(t, actualCode, "var options *PrintOpts")
 	assertCodeContains(t, actualCode, "options = new(PrintOpts)")
-
-	// 1. Default value
 	assertCodeContains(t, actualCode, `options.Greeting = "hello \"world\""`)
-	// 2. Env Var (not in this test's metadata)
-	// 3. Set Flag
 	expectedFlagParsing := `flag.StringVar(&options.Greeting, "greeting", options.Greeting, "A greeting message" /* Original Default: hello "world", Env: */)`
 	assertCodeContains(t, actualCode, expectedFlagParsing)
 }
@@ -916,7 +666,7 @@ func TestGenerateMain_WithHelpText(t *testing.T) {
 	cmdMeta := &metadata.CommandMetadata{
 		RunFunc: &metadata.RunFuncInfo{
 			Name:                       "RunMyTool",
-			PackageName:                "mytool",
+			PackageName:                "main",
 			OptionsArgTypeNameStripped: "ToolOptions",
 			OptionsArgIsPointer:        true,
 		},
@@ -926,11 +676,10 @@ func TestGenerateMain_WithHelpText(t *testing.T) {
 	}
 	helpText := "This is my custom help message.\nUsage: mytool -input <file>"
 
-	actualCode, err := GenerateMain(cmdMeta, helpText, true) // Changed codegen.GenerateMain to GenerateMain
+	actualCode, err := GenerateMain(cmdMeta, helpText, true)
 	if err != nil {
 		t.Fatalf("GenerateMain with help text failed: %v", err)
 	}
-
 	assertCodeContains(t, actualCode, "var options *ToolOptions")
 	assertCodeContains(t, actualCode, "options = new(ToolOptions)")
 	expectedHelpTextSnippet := `
@@ -938,48 +687,43 @@ func TestGenerateMain_WithHelpText(t *testing.T) {
 		fmt.Fprint(os.Stderr, ` + "`" + helpText + "`" + `)
 	}`
 	assertCodeContains(t, actualCode, expectedHelpTextSnippet)
-
 	oldManualHelpLogic := `for _, arg := range os.Args[1:] { if arg == "-h" || arg == "--help" {`
 	assertCodeNotContains(t, actualCode, oldManualHelpLogic)
-
 	assertCodeContains(t, actualCode, `flag.StringVar(&options.Input, "input", options.Input, "Input file")`)
-	assertCodeContains(t, actualCode, "err := RunMyTool(options)") // TODO: mytool.RunMyTool(options)
+	assertCodeContains(t, actualCode, "err = RunMyTool(options)")
 }
 
 func TestGenerateMain_WithEmptyHelpText(t *testing.T) {
 	cmdMeta := &metadata.CommandMetadata{
 		RunFunc: &metadata.RunFuncInfo{
 			Name:                       "AnotherTool",
-			PackageName:                "othertool",
-			OptionsArgTypeNameStripped: "NoOptions",
-			OptionsArgIsPointer:        true,
+			PackageName:                "main",
+			OptionsArgTypeNameStripped: "",
+			OptionsArgIsPointer:        false,
 		},
 		Options: []*metadata.OptionMetadata{},
 	}
 
-	actualCode, err := GenerateMain(cmdMeta, "", true) // Changed codegen.GenerateMain to GenerateMain
+	actualCode, err := GenerateMain(cmdMeta, "", true)
 	if err != nil {
 		t.Fatalf("GenerateMain with empty help text failed: %v", err)
 	}
-
 	unexpectedHelpLogic := `
 	// Handle -h/--help flags
 	for _, arg := range os.Args[1:] {
 `
 	assertCodeNotContains(t, actualCode, unexpectedHelpLogic)
-
 	unexpectedFlagUsageAssignment := `flag.Usage = func()`
 	assertCodeNotContains(t, actualCode, unexpectedFlagUsageAssignment)
-
 	assertCodeContains(t, actualCode, "func main() {")
-	assertCodeContains(t, actualCode, "err := AnotherTool()") // TODO: othertool.AnotherTool()
+	assertCodeContains(t, actualCode, "err = AnotherTool()")
 }
 
 func TestGenerateMain_HelpTextNewlineFormatting(t *testing.T) {
 	baseCmdMeta := &metadata.CommandMetadata{
 		RunFunc: &metadata.RunFuncInfo{
 			Name:                       "RunMyTool",
-			PackageName:                "mytool",
+			PackageName:                "main",
 			OptionsArgTypeNameStripped: "ToolOptions",
 			OptionsArgIsPointer:        true,
 		},
@@ -988,23 +732,15 @@ func TestGenerateMain_HelpTextNewlineFormatting(t *testing.T) {
 
 	t.Run("WithNewlines", func(t *testing.T) {
 		helpTextWithNewlines := "This is line one.\nThis is line two."
-
-		actualCode, err := GenerateMain(baseCmdMeta, helpTextWithNewlines, true) // Changed codegen.GenerateMain to GenerateMain
+		actualCode, err := GenerateMain(baseCmdMeta, helpTextWithNewlines, true)
 		if err != nil {
 			t.Fatalf("GenerateMain with help text failed: %v", err)
 		}
-
 		formattedActualCode, err := format.Source([]byte(actualCode))
 		if err != nil {
 			t.Fatalf("Failed to format actual generated code: %v\nOriginal code:\n%s", err, actualCode)
 		}
-
-		// This test expects formatHelpText to produce a raw string literal for multi-line strings.
-		// The old formatHelpText did: return "`" + text + "`"
-		// The new one does too, if no backticks are present: return "`" + processedText + "`"
-		// "This is line one.\nThis is line two." (after \\n processing) becomes `This is line one.\nThis is line two.`
 		expectedUsageFunc := "fmt.Fprint(os.Stderr, `This is line one.\nThis is line two.`)"
-
 		if !strings.Contains(string(formattedActualCode), expectedUsageFunc) {
 			t.Errorf("Expected generated code to contain exact snippet for multiline help text with raw string literal.\nExpected snippet:\n%s\n\nFormatted actual code:\n%s", expectedUsageFunc, string(formattedActualCode))
 		}
@@ -1012,22 +748,16 @@ func TestGenerateMain_HelpTextNewlineFormatting(t *testing.T) {
 
 	t.Run("WithoutNewlines", func(t *testing.T) {
 		helpTextWithoutNewlines := "This is a single line."
-		// Old formatHelpText: return fmt.Sprintf("%q", text)
-		// New formatHelpText (no newlines, no backticks): return fmt.Sprintf("%q", processedText)
-		// So, "This is a single line." becomes "\"This is a single line.\""
 		expectedFormattedText := fmt.Sprintf("%q", helpTextWithoutNewlines)
 		expectedSnippet := fmt.Sprintf("fmt.Fprint(os.Stderr, %s)", expectedFormattedText)
-
-		actualCode, err := GenerateMain(baseCmdMeta, helpTextWithoutNewlines, true) // Changed codegen.GenerateMain to GenerateMain
+		actualCode, err := GenerateMain(baseCmdMeta, helpTextWithoutNewlines, true)
 		if err != nil {
 			t.Fatalf("GenerateMain with help text failed: %v", err)
 		}
-
 		formattedActualCode, err := format.Source([]byte(actualCode))
 		if err != nil {
 			t.Fatalf("Failed to format actual generated code: %v\nOriginal code:\n%s", err, actualCode)
 		}
-
 		if !strings.Contains(string(formattedActualCode), expectedSnippet) {
 			t.Errorf("Expected generated code to contain exact snippet for single line help text with quoted string literal.\nExpected snippet:\n%s\n\nFormatted actual code:\n%s", expectedSnippet, string(formattedActualCode))
 		}
@@ -1036,15 +766,15 @@ func TestGenerateMain_HelpTextNewlineFormatting(t *testing.T) {
 
 func TestGenerateMain_WithInitializer(t *testing.T) {
 	cmdMeta := &metadata.CommandMetadata{
-		Name: "example.com/user/usercmd", // Used for import path
+		Name: "example.com/user/usercmd",
 		RunFunc: &metadata.RunFuncInfo{
 			Name:                       "Run",
-			PackageName:                "usercmd", // Package of the Run func and InitializerFunc
+			PackageName:                "main",
 			OptionsArgTypeNameStripped: "MyOptions",
 			OptionsArgIsPointer:        true,
 			InitializerFunc:            "NewMyOptions",
 		},
-		Options: []*metadata.OptionMetadata{}, // Options are not needed as initializer handles them
+		Options: []*metadata.OptionMetadata{},
 	}
 
 	helpText := "Test command with initializer"
@@ -1052,36 +782,23 @@ func TestGenerateMain_WithInitializer(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateMain with initializer failed: %v\nGenerated code:\n%s", err, actualCode)
 	}
-
-	// Check for import of the user's command package
-	assertCodeContains(t, actualCode, `import "example.com/user/usercmd"`)
-
-	// Check for options initialization using the InitializerFunc
-	// Now expects no package prefix as initializer is assumed to be in 'main' by analyzer
+	assertCodeNotContains(t, actualCode, `import . "example.com/user/usercmd"`)
+	assertCodeNotContains(t, actualCode, `import "example.com/user/usercmd"`)
 	assertCodeContains(t, actualCode, "options = NewMyOptions()")
-
-	// Check that per-field default setting is NOT present
-	// (difficult to assert absence of a potentially large block,
-	// but we can check for a common pattern if one existed, e.g. "options.FieldName =")
-	// For this test, the main check is the presence of InitializerFunc call.
-	// We can also check that "options = new(MyOptions)" is NOT present.
 	assertCodeNotContains(t, actualCode, "options = new(MyOptions)")
 	assertCodeNotContains(t, actualCode, "var options = &MyOptions{}")
-
-
-	// Check for the call to the user's run function
-	assertCodeContains(t, actualCode, "err := usercmd.Run(options)")
+	assertCodeContains(t, actualCode, "err = Run(options)")
 }
 
 func TestGenerateMain_WithoutInitializer_Fallback(t *testing.T) {
 	cmdMeta := &metadata.CommandMetadata{
-		Name: "example.com/user/usercmd", // Used for import path
+		Name: "example.com/user/usercmd",
 		RunFunc: &metadata.RunFuncInfo{
 			Name:                       "Run",
-			PackageName:                "usercmd",
+			PackageName:                "main",
 			OptionsArgTypeNameStripped: "MyOptions",
 			OptionsArgIsPointer:        true,
-			InitializerFunc:            "", // No initializer
+			InitializerFunc:            "",
 		},
 		Options: []*metadata.OptionMetadata{
 			{Name: "Mode", TypeName: "string", DefaultValue: "test", HelpText: "Operation mode"},
@@ -1094,36 +811,23 @@ func TestGenerateMain_WithoutInitializer_Fallback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateMain without initializer failed: %v\nGenerated code:\n%s", err, actualCode)
 	}
-
-	// Check for import of the user's command package
-	assertCodeContains(t, actualCode, `import "example.com/user/usercmd"`)
-
-	// Check that initializer call is NOT present
+	assertCodeNotContains(t, actualCode, `import . "example.com/user/usercmd"`)
+	assertCodeNotContains(t, actualCode, `import "example.com/user/usercmd"`)
 	assertCodeNotContains(t, actualCode, "usercmd.NewMyOptions()")
-
-	// Check for "options = new(MyOptions)" or "var options *MyOptions; options = new(MyOptions)"
-	// The template uses `options = new({{.RunFunc.OptionsArgTypeNameStripped}})`
 	assertCodeContains(t, actualCode, "options = new(MyOptions)")
-
-	// Check for per-field default settings
 	assertCodeContains(t, actualCode, `options.Mode = "test"`)
 	assertCodeContains(t, actualCode, `options.Count = 42`)
-
-	// Check for flag setup for these fields
 	assertCodeContains(t, actualCode, `flag.StringVar(&options.Mode, "mode", options.Mode, "Operation mode" /* Original Default: test, Env: */)`)
 	assertCodeContains(t, actualCode, `flag.IntVar(&options.Count, "count", options.Count, "A number" /* Original Default: 42, Env: */)`)
-
-
-	// Check for the call to the user's run function
-	assertCodeContains(t, actualCode, "err := usercmd.Run(options)")
+	assertCodeContains(t, actualCode, "err = Run(options)")
 }
 
 func TestGenerateMain_InitializerInMainPackage(t *testing.T) {
 	cmdMeta := &metadata.CommandMetadata{
-		Name: "main", // targetPackageID, used for cmdMeta.Name
+		Name: "main",
 		RunFunc: &metadata.RunFuncInfo{
 			Name:                       "Run",
-			PackageName:                "main", // Package of the Run func and InitializerFunc
+			PackageName:                "main",
 			OptionsArgTypeNameStripped: "MyOptions",
 			OptionsArgIsPointer:        true,
 			InitializerFunc:            "NewMyOptions",
@@ -1136,20 +840,11 @@ func TestGenerateMain_InitializerInMainPackage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateMain with initializer in main package failed: %v\nGenerated code:\n%s", err, actualCode)
 	}
-
-	// Check that "main" is NOT imported
 	assertCodeNotContains(t, actualCode, `import "main"`)
-
-	// Check for options initialization using the InitializerFunc (no package prefix)
 	assertCodeContains(t, actualCode, "options = NewMyOptions()")
-
-	// Check that per-field default setting is NOT present
 	assertCodeNotContains(t, actualCode, "options = new(MyOptions)")
 	assertCodeNotContains(t, actualCode, "var options = &MyOptions{}")
-
-
-	// Check for the call to the user's run function (no package prefix)
-	assertCodeContains(t, actualCode, "err := Run(options)")
+	assertCodeContains(t, actualCode, "err = Run(options)")
 }
 
 
@@ -1193,8 +888,6 @@ func TestFormatHelpText(t *testing.T) {
 		{
 			name:  "pre-existing newline and single quote to backtick",
 			input: "Pre-existing newline\nAnd pre-existing 'backtick'.",
-			// After initial processing: "Pre-existing newline\nAnd pre-existing `backtick`."
-			// Contains newline and backtick, so:
 			want: "`Pre-existing newline\nAnd pre-existing ` + \"`\" + `backtick` + \"`\" + `.`",
 		},
 		{
@@ -1204,17 +897,17 @@ func TestFormatHelpText(t *testing.T) {
 		},
 		{
 			name:  "only escaped newline",
-			input: "\\n", // becomes "\n"
+			input: "\\n",
 			want:  "`\n`",
 		},
 		{
 			name:  "only single quote",
-			input: "'", // becomes "`"
+			input: "'",
 			want:  "\"`\"",
 		},
 		{
 			name:  "multiple backticks and newlines",
-			input: "A\\nB'C'D\\nE'F'G", // becomes "A\nB`C`D\nE`F`G"
+			input: "A\\nB'C'D\\nE'F'G",
 			want:  "`A\nB` + \"`\" + `C` + \"`\" + `D\nE` + \"`\" + `F` + \"`\" + `G`",
 		},
 	}
@@ -1222,7 +915,6 @@ func TestFormatHelpText(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := formatHelpText(tt.input); got != tt.want {
-				// Using fmt.Sprintf for got and want to make invisible characters visible
 				t.Errorf("formatHelpText(%q) = %s, want %s", tt.input, fmt.Sprintf("%q", got), fmt.Sprintf("%q", tt.want))
 			}
 		})


### PR DESCRIPTION
…ackage assumption.

Here's a summary of what I did:

- In `internal/codegen/main_generator.go`:
    - I updated the code generation template to ensure all run functions and initializer functions are called without package prefixes. This matches the project's current approach where command functions are treated as if they are in the `main` package.
    - I removed the logic for importing user-defined packages, as it's not needed under this "main package" assumption.
    - I standardized error variable names in the template (for instance, changing `errConv` to `err`).
    - I added handling for `[]string` type options from environment variables.

- In `internal/codegen/main_generator_test.go`:
    - I aligned all test assertions and metadata (like setting `RunFunc.PackageName = "main"`) with the generator changes.
    - I made sure the tests expect direct function calls and no user package imports.
    - All Go unit tests are now passing.

- Regarding the examples:
    - I fixed syntax errors in `examples/hello/main.go`.
    - I successfully ran `make examples-emit` for `examples/hello/main.go`.
    - I couldn't update `examples/fullset/main.go` due to a persistent issue during analysis: "could not import github.com/podhmo/goat (invalid package name: \"\")". This issue with `fullset` is still outstanding.