### PR TITLE
docs: Update examples and add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing to goat
+
+Thank you for considering contributing to `goat`!
+
+## Development Workflow
+
+1.  **Make your changes:** Implement your bug fix or feature.
+2.  **Update Examples (if applicable):**
+    If your changes affect the CLI generation (e.g., modify how `Options` structs are parsed, add new marker functions, or change generated code), you should update the code examples.
+    - The primary example for showcasing features is `examples/fullset/main.go`.
+    - The example in the main `README.md` should be kept concise.
+3.  **Regenerate Example Code:**
+    After updating example sources (like `examples/fullset/main.go`), you need to regenerate the `main()` function within those examples using:
+    ```bash
+    make examples-emit
+    ```
+    Alternatively, you can run `go generate` directly on the specific example file if you've configured its `//go:generate` directive appropriately. For instance:
+    ```bash
+    go generate ./examples/fullset/main.go
+    ```
+4.  **Test your changes:** Ensure all tests pass.
+    ```bash
+    go test ./...
+    ```
+5.  **Commit and Push:** Commit your changes with a clear message and push to your fork.
+6.  **Open a Pull Request:** Submit a PR against the main `goat` repository.
+
+## Known Issues
+
+### `make examples-emit` and `examples/fullset/main.go`
+
+Currently, the `goat emit` command has an internal issue when processing Go files that directly import the `github.com/podhmo/goat` package itself (as `examples/fullset/main.go` does). This results in an error like:
+
+`ERROR ... could not import github.com/podhmo/goat (invalid package name: "")`
+
+This prevents `make examples-emit` (or direct `go generate` on `examples/fullset/main.go`) from successfully regenerating the `main()` function for this specific example.
+
+While the source code of `examples/fullset/main.go` should be kept up-to-date to reflect all features, the generated `main()` function within it might be stale until this underlying issue in the `goat` tool is resolved. Other examples that do not import `github.com/podhmo/goat` (like `examples/hello/main.go`) should process correctly.
+
+Please be aware of this limitation when working with the `fullset` example.

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ examples-check:
 
 examples-emit:
 	go run ./cmd/goat/ emit examples/hello/main.go
-	go run ./cmd/goat/ emit -initializer newOptions examples/fullset/main.go
+	go run ./cmd/goat/ emit -run FullsetRun -initializer NewFullsetOptions examples/fullset/main.go
 .PHONY: examples-emit
 
 # format the code

--- a/examples/hello/main.go
+++ b/examples/hello/main.go
@@ -83,6 +83,11 @@ Flags:
 	}
 
 	// End of range .Options for required checks
+
+	// TODO: Implement runtime validation for file options based on metadata:
+	// - Check for opt.FileMustExist (e.g., using os.Stat)
+	// - Handle opt.FileGlobPattern (e.g., using filepath.Glob)
+	// Currently, these attributes are parsed but not enforced at runtime by the generated CLI.
 	// End of if .RunFunc.OptionsArgTypeNameStripped (options handling block)
 
 	var err error


### PR DESCRIPTION
- Enhanced `examples/fullset/main.go` to showcase more features:
    - Uses `net.IP` to demonstrate `flag.TextVar` with a built-in type.
    - Demonstrates various field types (string, int, bool, pointers, slices).
    - Incorporates `goat.File`, `goat.MustExist`, `goat.GlobPattern` markers.
    - Shows required bools defaulting to true (generating `--no-<flag>`).
    - Updated to use direct `goat.` calls instead of an import alias.
- Updated `Makefile` to use correct function names for `fullset` example.
- Kept `README.md` example concise per your feedback.
- Added `CONTRIBUTING.md` with development workflow and a note about the known issue with `make examples-emit` for `examples/fullset/main.go` due to an internal limitation.

Note: `make examples-emit` for `examples/fullset/main.go` still fails due to an internal issue with parsing files that import its own module. The source code of `examples/fullset/main.go` is correct, but its `main()` cannot be regenerated by the current version.