### PR TITLE
docs: listing fix goat generation issues in examples/fullset

### DIFF
--- a/examples/fullset/main.go
+++ b/examples/fullset/main.go
@@ -13,6 +13,11 @@ import (
 	"github.com/podhmo/goat"
 )
 
+// stringPtr is a helper function to get a pointer to a string.
+func stringPtr(s string) *string {
+	return &s
+}
+
 //go:generate goat emit -run FullsetRun -initializer NewFullsetOptions main.go
 
 // Options defines the command line options for this simple example tool.
@@ -64,18 +69,24 @@ func NewFullsetOptions() *Options {
 		Name:      goat.Default("World"),
 		LogLevel:  goat.Default("info", goat.Enum([]string{"debug", "info", "warning", "error"})),
 		OutputDir: goat.Default("output"),
-		Mode:      goat.Enum([]string{"standard", "turbo", "eco"}),
+		Mode:      goat.Default("standard", goat.Enum([]string{"standard", "turbo", "eco"})),
 		// Age is optional (pointer) and has no default here. It remains *int.
 		// Features is []string, handled by flag package. Env var should work.
 		// SuperVerbose is a bool, defaults to false (zero value for bool).
 
 		// New fields from first subtask, adapted for current subtask
 		// OptionalToggle is *bool and should not have goat.Default()
+		// TODO: The goat tool fails to parse the following line for ConfigFile.
+		// TODO: It reports an error: "in call to goat.Default, type string of goat.File(...) does not match []T (cannot infer T)".
+		// TODO: This suggests an issue with how goat's parser handles goat.File when nested in goat.Default, potentially misinterpreting goat.File's return type.
 		ConfigFile: goat.Default("config.json", goat.File("config.json", goat.MustExist())),
+		// TODO: The goat tool fails to parse the following line for Pattern.
+		// TODO: It reports an error: "in call to goat.Default, type string of goat.File(...) does not match []T (cannot infer T)".
+		// TODO: This suggests an issue with how goat's parser handles goat.File when nested in goat.Default, potentially misinterpreting goat.File's return type.
 		Pattern:    goat.Default("*.go", goat.File("*.go", goat.GlobPattern())),
 		EnableFeatureX: goat.Default(true),
 		HostIP:     goat.Default(net.ParseIP("127.0.0.1")),
-		ExistingFieldToMakeOptional: goat.Default("was set by default"),
+		ExistingFieldToMakeOptional: goat.Default(stringPtr("was set by default")),
 	}
 }
 
@@ -336,7 +347,7 @@ Defaults to "output" if not specified by the user.` /* Original Default: output,
 	// End of range .Options for required checks
 	// End of if .HasOptions
 
-	err := run(*options)
+	err := FullsetRun(*options)
 
 	if err != nil {
 		slog.Error("Runtime error", "error", err)


### PR DESCRIPTION
Fix goat generation issues in examples/fullset

This commit addresses several problems that prevented the `goat` tool
from successfully parsing and generating code for `examples/fullset/main.go`.

Changes include:
- Corrected the initialization of the `Mode` field in `NewFullsetOptions`
  to use `goat.Default` correctly with `goat.Enum`.
- Fixed the initialization of `ExistingFieldToMakeOptional` by using
  `goat.Default` with a helper function `stringPtr` to provide a `*string`.
- Corrected the call to the run function in `main()` to use `FullsetRun`.
- Added a `stringPtr` helper function to `main.go`.

Persistent issues with `goat.File`:
The `goat` tool continues to fail parsing the `ConfigFile` and `Pattern`
fields when `goat.File(...)` is used as a validator within `goat.Default(...)`.
The error reported is:
  "in call to goat.Default, type string of goat.File(...) does not match []T (cannot infer T)"
Detailed TODO comments have been added above these lines in
`NewFullsetOptions` to highlight this unresolved issue, which may
indicate a bug in the `goat` tool's parser or a misunderstanding of
its intended usage for these specific validators.
