### PR TITLE
feat: Add AnalyzeOptionsV3 for lazy import evaluation

### DIFF
--- a/examples/enum/main.go
+++ b/examples/enum/main.go
@@ -2,8 +2,6 @@ package enum
 
 import (
 	"fmt"
-	"log/slog"
-	"os"
 
 	"github.com/podhmo/goat"
 	"github.com/podhmo/goat/examples/enum/customtypes"
@@ -43,8 +41,8 @@ type Options struct {
 func NewOptions() *Options {
 	return &Options{
 		LocalEnumField: goat.Default(LocalA, goat.Enum(GetLocalEnumsAsStrings())),
-// TODO: Since it's a generic function, there should be no need to cast it to a string type.If there are reasons why it is not possible, I want to resolve them.
-		ImportedEnumField: goat.Default(customtypes.OptionX, goat.Enum(customtypes.GetCustomEnumOptionsAsStrings())),
+		// TODO: Since it's a generic function, there should be no need to cast it to a string type.If there are reasons why it is not possible, I want to resolve them.
+		ImportedEnumField:         goat.Default(customtypes.OptionX, goat.Enum(customtypes.GetCustomEnumOptionsAsStrings())),
 		OptionalImportedEnumField: goat.Enum(nil, []string{string(customtypes.OptionX), string(customtypes.OptionY)}),
 	}
 }
@@ -52,14 +50,11 @@ func NewOptions() *Options {
 // Run is the main execution logic for the enum example CLI.
 // It prints the selected enum values.
 func Run(opts Options) error {
-	fmt.Printf("Selected Local Enum: %s
-", opts.LocalEnumField)
-	fmt.Printf("Selected Imported Enum: %s
-", opts.ImportedEnumField)
+	fmt.Printf("Selected Local Enum: %s\n", opts.LocalEnumField)
+	fmt.Printf("Selected Imported Enum: %s\n", opts.ImportedEnumField)
 
 	if opts.OptionalImportedEnumField != nil {
-		fmt.Printf("Selected Optional Imported Enum: %s
-", *opts.OptionalImportedEnumField)
+		fmt.Printf("Selected Optional Imported Enum: %s\n", *opts.OptionalImportedEnumField)
 	} else {
 		fmt.Println("Optional Imported Enum: not set")
 	}

--- a/examples/fullset/main.go
+++ b/examples/fullset/main.go
@@ -4,11 +4,11 @@ import (
 	"flag"
 	"fmt"
 	"log/slog"
+	"net"
 	"os"
 	"slices"
 	"strconv"
 	"strings"
-	"net"
 
 	"github.com/podhmo/goat"
 )
@@ -83,9 +83,9 @@ func NewFullsetOptions() *Options {
 		// TODO: The goat tool fails to parse the following line for Pattern.
 		// TODO: It reports an error: "in call to goat.Default, type string of goat.File(...) does not match []T (cannot infer T)".
 		// TODO: This suggests an issue with how goat's parser handles goat.File when nested in goat.Default, potentially misinterpreting goat.File's return type.
-		Pattern:    goat.Default("*.go", goat.File("*.go", goat.GlobPattern())),
-		EnableFeatureX: goat.Default(true),
-		HostIP:     goat.Default(net.ParseIP("127.0.0.1")),
+		Pattern:                     goat.Default("*.go", goat.File("*.go", goat.GlobPattern())),
+		EnableFeatureX:              goat.Default(true),
+		HostIP:                      goat.Default(net.ParseIP("127.0.0.1")),
 		ExistingFieldToMakeOptional: goat.Default(stringPtr("was set by default")),
 	}
 }

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -38,7 +38,6 @@ func Analyze(fset *token.FileSet, files []*ast.File, runFuncName string, targetP
 	pkgNameParts := strings.Split(targetPackageID, "/")
 	runFuncInfo.PackageName = pkgNameParts[len(pkgNameParts)-1]
 
-
 	// Populate OptionsArgTypeNameStripped and OptionsArgIsPointer
 	if runFuncInfo.OptionsArgType != "" {
 		if strings.HasPrefix(runFuncInfo.OptionsArgType, "*") {

--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -7,9 +7,9 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+
 	// "strings" // No longer used directly in the simplified parseTestFiles
 	"testing"
-
 	// "golang.org/x/tools/go/packages" // No longer used in the simplified parseTestFiles
 )
 
@@ -63,7 +63,6 @@ func parseTestFiles(t *testing.T, sources map[string]string) (*token.FileSet, []
 
 	return fset, []*ast.File{astFile}, tempDir
 }
-
 
 func TestAnalyze_InitializerFunctionDiscovery(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))

--- a/internal/analyzer/options_analyzer.go
+++ b/internal/analyzer/options_analyzer.go
@@ -3,9 +3,11 @@ package analyzer
 import (
 	"fmt"
 	"go/ast"
+
 	// "go/build" // Unused
 	"go/token"
 	"go/types"
+
 	// "log/slog" // Unused
 	"os"            // Re-add for ReadDir
 	"path/filepath" // Re-add for Join
@@ -19,8 +21,7 @@ import (
 	"github.com/podhmo/goat/internal/metadata"
 	"github.com/podhmo/goat/internal/utils/astutils"
 	"github.com/podhmo/goat/internal/utils/stringutils"
-
-	"go/parser" // Added for V3
+	// Added for V3
 	// "golang.org/x/tools/go/importer" // May need for V3 type checking without go/packages
 )
 

--- a/internal/analyzer/options_analyzer.go
+++ b/internal/analyzer/options_analyzer.go
@@ -7,7 +7,7 @@ import (
 	"go/token"
 	"go/types"
 	// "log/slog" // Unused
-	"os" // Re-add for ReadDir
+	"os"            // Re-add for ReadDir
 	"path/filepath" // Re-add for Join
 	"reflect"
 	"strings"
@@ -19,6 +19,9 @@ import (
 	"github.com/podhmo/goat/internal/metadata"
 	"github.com/podhmo/goat/internal/utils/astutils"
 	"github.com/podhmo/goat/internal/utils/stringutils"
+
+	"go/parser" // Added for V3
+	// "golang.org/x/tools/go/importer" // May need for V3 type checking without go/packages
 )
 
 var (
@@ -33,7 +36,7 @@ func init() {
 		nil, // recv type params
 		nil, // type params
 		types.NewTuple(types.NewParam(token.NoPos, nil, "", types.NewSlice(types.Universe.Lookup("byte").Type()))), // params
-		types.NewTuple(types.NewParam(token.NoPos, nil, "", types.Universe.Lookup("error").Type())), // results
+		types.NewTuple(types.NewParam(token.NoPos, nil, "", types.Universe.Lookup("error").Type())),                // results
 		false, // variadic
 	))
 	textUnmarshalerType = types.NewInterfaceType([]*types.Func{textUnmarshalerMeth}, nil).Complete()
@@ -54,17 +57,17 @@ func init() {
 }
 
 // AnalyzeOptionsV2 finds the Options struct definition using an on-disk temporary module structure.
-// - fset: Token fileset for parsing.
-// - astFilesForLookup: ASTs of files in the target package, primarily used to locate the options struct AST.
-//                      These ASTs must have been parsed from files whose paths are on disk.
-// - optionsTypeName: Name of the options struct type (e.g., "MainConfig").
-// - targetPackageID: The import path of the package containing optionsTypeName (e.g., "testmodule/example.com/mainpkg").
-// - moduleRootPath: Absolute path to the root of the temporary module (where go.mod is).
+//   - fset: Token fileset for parsing.
+//   - astFilesForLookup: ASTs of files in the target package, primarily used to locate the options struct AST.
+//     These ASTs must have been parsed from files whose paths are on disk.
+//   - optionsTypeName: Name of the options struct type (e.g., "MainConfig").
+//   - targetPackageID: The import path of the package containing optionsTypeName (e.g., "testmodule/example.com/mainpkg").
+//   - moduleRootPath: Absolute path to the root of the temporary module (where go.mod is).
 func AnalyzeOptionsV2(fset *token.FileSet, astFilesForLookup []*ast.File, optionsTypeName string, targetPackageID string, moduleRootPath string) ([]*metadata.OptionMetadata, string, error) {
 	cfg := &packages.Config{
 		Fset:    fset,
 		Mode:    packages.NeedName | packages.NeedFiles | packages.NeedSyntax | packages.NeedTypes | packages.NeedTypesInfo | packages.NeedImports | packages.NeedModule,
-		Dir:     moduleRootPath, // Root of the temporary module
+		Dir:     moduleRootPath,          // Root of the temporary module
 		Overlay: make(map[string][]byte), // Overlay is not strictly needed if all files are on disk and up-to-date
 		// Env: os.Environ(), // Inherit environment
 	}
@@ -138,7 +141,6 @@ func AnalyzeOptionsV2(fset *token.FileSet, astFilesForLookup []*ast.File, option
 		return nil, "", fmt.Errorf("target package '%s' not found among loaded packages: %v. (cfg.Dir='%s', patterns=%q)", targetPackageID, foundPkgIDs, cfg.Dir, loadPatterns)
 	}
 
-
 	// Remove potential module prefix from optionsTypeName if it's fully qualified
 	// e.g. "testmodule/example.com/mainpkg.MainConfig" -> "MainConfig"
 	// The optionsTypeName should be the simple name for lookup within the package's ASTs.
@@ -151,9 +153,8 @@ func AnalyzeOptionsV2(fset *token.FileSet, astFilesForLookup []*ast.File, option
 		simpleOptionsTypeName = simpleOptionsTypeName[1:]
 	}
 
-
 	var optionsStruct *ast.TypeSpec
-	var actualStructName string       // This will be simpleOptionsTypeName if found
+	var actualStructName string               // This will be simpleOptionsTypeName if found
 	var fileContainingOptionsStruct *ast.File // The AST of the file where the struct is defined
 
 	// Iterate through the ASTs that belong to the currentPkg to find the struct.
@@ -183,7 +184,6 @@ func AnalyzeOptionsV2(fset *token.FileSet, astFilesForLookup []*ast.File, option
 	if fileContainingOptionsStruct == nil { // Should be set if optionsStruct is not nil
 		return nil, "", fmt.Errorf("internal error: options struct '%s' found but its containing AST was not identified within package %s", actualStructName, currentPkg.ID)
 	}
-
 
 	structType, ok := optionsStruct.Type.(*ast.StructType)
 	if !ok {
@@ -238,7 +238,7 @@ func AnalyzeOptionsV2(fset *token.FileSet, astFilesForLookup []*ast.File, option
 				// as the relevant ASTs are already loaded by packages.Load and are in pkg.Syntax.
 				// The ASTs for the external package are in resolvedImportedPkg.Syntax
 				if resolvedImportedPkg == nil { // Should not happen if foundImportMatchingSelector is true
-					 return nil, actualStructName, fmt.Errorf("internal error: resolvedImportedPkg is nil for selector '%s'", pkgSelectorInAST)
+					return nil, actualStructName, fmt.Errorf("internal error: resolvedImportedPkg is nil for selector '%s'", pkgSelectorInAST)
 				}
 				relevantASTsForExternal := resolvedImportedPkg.Syntax
 				if len(relevantASTsForExternal) == 0 && resolvedImportedPkg.Name != "" { // Check PkgPath for stdlib
@@ -248,7 +248,6 @@ func AnalyzeOptionsV2(fset *token.FileSet, astFilesForLookup []*ast.File, option
 					// This logic assumes all analyzed structs (even from stdlib) will have their ASTs available.
 					// For now, proceed; if typeNameInExternalPkg is not found, it will error appropriately.
 				}
-
 
 				embeddedOptions, _, err = AnalyzeOptionsV2(fset, relevantASTsForExternal, typeNameInExternalPkg, externalPkgImportPath, moduleRootPath)
 			} else { // Embedded struct from the same package
@@ -302,10 +301,18 @@ func AnalyzeOptionsV2(fset *token.FileSet, astFilesForLookup []*ast.File, option
 				// Try TypeOf if Defs fails.
 				tv := currentPkg.TypesInfo.TypeOf(field.Type)
 				if tv != nil {
-					if types.Implements(tv, textUnmarshalerType) { opt.IsTextUnmarshaler = true }
-					if !opt.IsTextUnmarshaler && types.Implements(types.NewPointer(tv), textUnmarshalerType) { opt.IsTextUnmarshaler = true }
-					if types.Implements(tv, textMarshalerType) { opt.IsTextMarshaler = true }
-					if !opt.IsTextMarshaler && types.Implements(types.NewPointer(tv), textMarshalerType) { opt.IsTextMarshaler = true }
+					if types.Implements(tv, textUnmarshalerType) {
+						opt.IsTextUnmarshaler = true
+					}
+					if !opt.IsTextUnmarshaler && types.Implements(types.NewPointer(tv), textUnmarshalerType) {
+						opt.IsTextUnmarshaler = true
+					}
+					if types.Implements(tv, textMarshalerType) {
+						opt.IsTextMarshaler = true
+					}
+					if !opt.IsTextMarshaler && types.Implements(types.NewPointer(tv), textMarshalerType) {
+						opt.IsTextMarshaler = true
+					}
 				}
 			}
 		}
@@ -333,6 +340,216 @@ func AnalyzeOptionsV2(fset *token.FileSet, astFilesForLookup []*ast.File, option
 	return extractedOptions, actualStructName, nil
 }
 
+// AnalyzeOptionsV3 finds the Options struct definition without using go/packages.
+// It was created to address issues with `go/packages`'s eager evaluation of all imports
+// (as used in AnalyzeOptionsV2), which can be slow and resource-intensive for large codebases
+// or when only a specific struct's definition is needed without full dependency resolution.
+// AnalyzeOptionsV3 aims for a lazier approach, parsing and type-checking only what is necessary.
+//
+//   - fset: Token fileset for parsing.
+//   - parsedFiles: A map of package import path to a list of already parsed AST files for that package.
+//     This allows V3 to potentially use pre-parsed files.
+//   - optionsTypeName: Name of the options struct type (e.g., "MainConfig").
+//   - targetPackagePath: The import path of the package containing optionsTypeName (e.g., "testmodule/example.com/mainpkg").
+//     This path should be resolvable to a directory on disk relative to some base (e.g., GOPATH/GOROOT).
+//   - baseDir: The base directory from which to resolve targetPackagePath. If empty, attempts to use GOROOT/GOPATH.
+func AnalyzeOptionsV3(
+	fset *token.FileSet,
+	parsedFiles map[string][]*ast.File, // Keyed by package import path
+	optionsTypeName string,
+	targetPackagePath string,
+	baseDir string, // Base directory to resolve targetPackagePath, can be module root or GOPATH/src etc.
+) ([]*metadata.OptionMetadata, string, error) {
+	// TODO: Implement logic to locate and parse Go files for targetPackagePath if not in parsedFiles.
+	//       This involves:
+	//       1. Resolving targetPackagePath to an actual directory path.
+	//          - Consider GOROOT, GOPATH, and vendor directories if baseDir is not sufficient.
+	//          - This is non-trivial due to module support and different project layouts.
+	//       2. Reading directory contents and parsing .go files (excluding _test.go).
+
+	var astFilesForLookup []*ast.File
+	var ok bool
+	if astFilesForLookup, ok = parsedFiles[targetPackagePath]; !ok {
+		// TODO: Parse files for targetPackagePath if not provided
+		// For now, assume they are provided or handle error
+		return nil, "", fmt.Errorf("files for package '%s' not found in parsedFiles and dynamic parsing not yet implemented", targetPackagePath)
+	}
+
+	if len(astFilesForLookup) == 0 {
+		return nil, "", fmt.Errorf("no AST files found for package '%s'", targetPackagePath)
+	}
+
+	// TODO: Type checking setup without go/packages.
+	//       This requires:
+	//       1. A types.Importer implementation. `go/importer.Default()` might work if source files are available
+	//          in standard locations (GOROOT/GOPATH). For modules, `golang.org/x/tools/go/packages/packagestest/importer`
+	//          or a custom importer that can resolve module paths might be needed.
+	//       2. Collecting all necessary ASTs (target package and its dependencies).
+	//       3. Running types.Config.Check to populate types.Info.
+	//       For now, TypesInfo will be nil, so TextUnmarshaler/Marshaler checks will be skipped.
+	var typesInfo *types.Info = nil // Placeholder
+
+	simpleOptionsTypeName := optionsTypeName
+	if strings.Contains(optionsTypeName, ".") {
+		parts := strings.Split(optionsTypeName, ".")
+		simpleOptionsTypeName = parts[len(parts)-1]
+	}
+	if strings.HasPrefix(simpleOptionsTypeName, "*") {
+		simpleOptionsTypeName = simpleOptionsTypeName[1:]
+	}
+
+	var optionsStruct *ast.TypeSpec
+	var actualStructName string
+	var fileContainingOptionsStruct *ast.File
+
+	for _, fileAst := range astFilesForLookup {
+		ast.Inspect(fileAst, func(n ast.Node) bool {
+			if ts, ok := n.(*ast.TypeSpec); ok {
+				if ts.Name.Name == simpleOptionsTypeName {
+					if _, isStruct := ts.Type.(*ast.StructType); isStruct {
+						optionsStruct = ts
+						actualStructName = ts.Name.Name
+						fileContainingOptionsStruct = fileAst
+						return false // Stop searching
+					}
+				}
+			}
+			return true
+		})
+		if optionsStruct != nil {
+			break
+		}
+	}
+
+	if optionsStruct == nil {
+		return nil, "", fmt.Errorf("options struct type '%s' (simple name '%s') not found in package '%s'", optionsTypeName, simpleOptionsTypeName, targetPackagePath)
+	}
+	if fileContainingOptionsStruct == nil {
+		return nil, "", fmt.Errorf("internal error: options struct '%s' found but its containing AST was not identified", actualStructName)
+	}
+
+	structType, ok := optionsStruct.Type.(*ast.StructType)
+	if !ok {
+		return nil, actualStructName, fmt.Errorf("type '%s' is not a struct type", actualStructName)
+	}
+
+	var extractedOptions []*metadata.OptionMetadata
+	for _, field := range structType.Fields.List {
+		if len(field.Names) == 0 { // Embedded struct
+			embeddedTypeName := astutils.ExprToTypeName(field.Type)
+			var embeddedOptions []*metadata.OptionMetadata
+			var err error
+
+			// TODO: Handle embedded structs. This is complex without go/packages because it requires:
+			//       1. Resolving the import path of the embedded type if it's from an external package.
+			//          - AST nodes for selectors (e.g., `pkg.Type`) only give the selector name (`pkg`).
+			//          - Need to map this selector to a full import path using the `import` declarations in the file.
+			//       2. Recursively calling AnalyzeOptionsV3 with the correct package path and files.
+			//          - This means the `parsedFiles` map needs to be populated for dependencies, or dynamic loading needs to work.
+
+			// Placeholder for current package name, true resolution is needed.
+			currentPkgIdentForRecursion := targetPackagePath
+			_ = currentPkgIdentForRecursion // avoid unused error for now
+
+			selParts := strings.SplitN(strings.TrimPrefix(embeddedTypeName, "*"), ".", 2)
+			if len(selParts) == 2 { // External package selector found
+				// pkgSelectorInAST := selParts[0]
+				// typeNameInExternalPkg := selParts[1]
+				// TODO: Resolve pkgSelectorInAST to full import path using fileContainingOptionsStruct.Imports
+				// TODO: Then call AnalyzeOptionsV3 for the external package.
+				// Example: embeddedOptions, _, err = AnalyzeOptionsV3(fset, parsedFiles, typeNameInExternalPkg, resolvedExternalPath, baseDir)
+				return nil, actualStructName, fmt.Errorf("analysis of embedded structs from external packages ('%s') not yet implemented in V3", embeddedTypeName)
+
+			} else { // Embedded struct from the same package
+				cleanEmbeddedTypeName := strings.TrimPrefix(embeddedTypeName, "*")
+				// TODO: Ensure astFilesForLookup are correctly passed for the same package recursion if needed,
+				//       or confirm if the current set is sufficient.
+				embeddedOptions, _, err = AnalyzeOptionsV3(fset, parsedFiles, cleanEmbeddedTypeName, targetPackagePath, baseDir)
+			}
+
+			if err != nil {
+				return nil, actualStructName, fmt.Errorf("error analyzing embedded struct '%s' (from type %s): %w", embeddedTypeName, targetPackagePath, err)
+			}
+			extractedOptions = append(extractedOptions, embeddedOptions...)
+			continue
+		}
+
+		fieldName := field.Names[0].Name
+		if !ast.IsExported(fieldName) {
+			continue
+		}
+
+		opt := &metadata.OptionMetadata{
+			Name:              fieldName,
+			CliName:           stringutils.ToKebabCase(fieldName),
+			TypeName:          astutils.ExprToTypeName(field.Type),
+			IsPointer:         astutils.IsPointerType(field.Type),
+			IsRequired:        !astutils.IsPointerType(field.Type),
+			IsTextUnmarshaler: false, // Requires type info
+			IsTextMarshaler:   false, // Requires type info
+		}
+
+		// TODO: Re-implement TextUnmarshaler/Marshaler checks using typesInfo if available.
+		// This was the original logic from V2:
+		if typesInfo != nil && field.Names[0] != nil {
+			obj := typesInfo.Defs[field.Names[0]]
+			if obj != nil {
+				tv := obj.Type()
+				if tv != nil {
+					if types.Implements(tv, textUnmarshalerType) {
+						opt.IsTextUnmarshaler = true
+					}
+					if !opt.IsTextUnmarshaler && types.Implements(types.NewPointer(tv), textUnmarshalerType) {
+						opt.IsTextUnmarshaler = true
+					}
+					if types.Implements(tv, textMarshalerType) {
+						opt.IsTextMarshaler = true
+					}
+					if !opt.IsTextMarshaler && types.Implements(types.NewPointer(tv), textMarshalerType) {
+						opt.IsTextMarshaler = true
+					}
+				}
+			} else {
+				tv := typesInfo.TypeOf(field.Type)
+				if tv != nil {
+					if types.Implements(tv, textUnmarshalerType) {
+						opt.IsTextUnmarshaler = true
+					}
+					if !opt.IsTextUnmarshaler && types.Implements(types.NewPointer(tv), textUnmarshalerType) {
+						opt.IsTextUnmarshaler = true
+					}
+					if types.Implements(tv, textMarshalerType) {
+						opt.IsTextMarshaler = true
+					}
+					if !opt.IsTextMarshaler && types.Implements(types.NewPointer(tv), textMarshalerType) {
+						opt.IsTextMarshaler = true
+					}
+				}
+			}
+		}
+
+		if field.Doc != nil {
+			opt.HelpText = strings.TrimSpace(field.Doc.Text())
+		}
+		if field.Comment != nil {
+			if opt.HelpText != "" {
+				opt.HelpText += "\n"
+			}
+			opt.HelpText += strings.TrimSpace(field.Comment.Text())
+			opt.HelpText = strings.TrimSpace(opt.HelpText)
+		}
+
+		if field.Tag != nil {
+			tagStr := strings.Trim(field.Tag.Value, "`")
+			tag := reflect.StructTag(tagStr)
+			if envVar, ok := tag.Lookup("env"); ok {
+				opt.EnvVar = envVar
+			}
+		}
+		extractedOptions = append(extractedOptions, opt)
+	}
+	return extractedOptions, actualStructName, nil
+}
 
 // Original AnalyzeOptions - keep for now if other parts of the codebase use it,
 // or remove if AnalyzeOptionsV2 is a direct replacement.

--- a/internal/analyzer/options_analyzer_test.go
+++ b/internal/analyzer/options_analyzer_test.go
@@ -796,8 +796,8 @@ type MainConfig struct {
     extpkg.ExternalEmbedded
 }`, externalPkgImportPath) // This import path won't be resolvable by V3's current stub
 
-	externalContent := `package extpkg
-type ExternalEmbedded struct { ExternalField bool }`
+	// externalContent := `package extpkg
+// type ExternalEmbedded struct { ExternalField bool }`
 
 	// Setup for V3: Create ASTs for both packages
 	packages := TestModulePackages{

--- a/internal/analyzer/options_analyzer_test.go
+++ b/internal/analyzer/options_analyzer_test.go
@@ -79,7 +79,6 @@ func createTestModuleInTempDir(t *testing.T, moduleName string, packages TestMod
 	return tempModRoot, astFiles, fset
 }
 
-
 // parseSingleFileAst is a helper to parse string content into an AST file.
 // DEPRECATED for multi-file/multi-package tests. Use createTestModuleInTempDir.
 func parseSingleFileAst(t *testing.T, content string) (*token.FileSet, *ast.File) {
@@ -146,9 +145,9 @@ type AnotherExternalEmbedded struct { Token string }`
 
 	expectedOptions := []*metadata.OptionMetadata{
 		{Name: "LocalName", CliName: "local-name", TypeName: "string", HelpText: "", IsRequired: true, EnvVar: "LOCAL_NAME"},
-		{Name: "IsRemote", CliName: "is-remote", TypeName: "bool", HelpText: "", IsRequired: true, EnvVar: "IS_REMOTE_TAG"},    // Help text from comments in original strings would be lost here.
-		{Name: "APIKey", CliName: "api-key", TypeName: "string", HelpText: "", IsRequired: true, EnvVar: "API_KEY_TAG"},      // Help text lost.
-		{Name: "Token", CliName: "token", TypeName: "string", HelpText: "", IsRequired: true, EnvVar: ""},                     // Help text lost.
+		{Name: "IsRemote", CliName: "is-remote", TypeName: "bool", HelpText: "", IsRequired: true, EnvVar: "IS_REMOTE_TAG"}, // Help text from comments in original strings would be lost here.
+		{Name: "APIKey", CliName: "api-key", TypeName: "string", HelpText: "", IsRequired: true, EnvVar: "API_KEY_TAG"},     // Help text lost.
+		{Name: "Token", CliName: "token", TypeName: "string", HelpText: "", IsRequired: true, EnvVar: ""},                   // Help text lost.
 	}
 
 	// Temporarily comment out the actual call to AnalyzeOptions until it's refactored.
@@ -238,7 +237,6 @@ func TestAnalyzeOptions_WithTextVarTypes(t *testing.T) {
 	}
 	tempModRoot, astFiles, fset := createTestModuleInTempDir(t, moduleName, packages)
 
-
 	expected := []struct {
 		name              string
 		isTextUnmarshaler bool
@@ -311,10 +309,10 @@ type Config struct {
 		expectedOptions []*metadata.OptionMetadata
 	}{
 		{
-			name:            "All not required (required tag ignored)",
-			pkgName:         "main", // Go package name in source
-			structName:      "Config",
-			tags:            []string{"`env:\"APP_NAME\"`", "`env:\"USER_AGE\"`", "", "`env:\"APP_FEATURES\"`"},
+			name:       "All not required (required tag ignored)",
+			pkgName:    "main", // Go package name in source
+			structName: "Config",
+			tags:       []string{"`env:\"APP_NAME\"`", "`env:\"USER_AGE\"`", "", "`env:\"APP_FEATURES\"`"},
 			expectedOptions: []*metadata.OptionMetadata{
 				{Name: "Name", CliName: "name", TypeName: "string", HelpText: "Name of the user.", IsRequired: true, EnvVar: "APP_NAME"},
 				{Name: "Age", CliName: "age", TypeName: "*int", HelpText: "Age of the user, optional.", IsPointer: true, IsRequired: false, EnvVar: "USER_AGE"},
@@ -334,7 +332,7 @@ type Config struct {
 
 			currentPkgPathSuffix := "." // Place in module root
 			packages := TestModulePackages{
-				currentPkgPathSuffix: { {Name: strings.ToLower(tc.structName) + ".go", Content: formattedContent} },
+				currentPkgPathSuffix: {{Name: strings.ToLower(tc.structName) + ".go", Content: formattedContent}},
 			}
 			tempModRoot, astFiles, fset := createTestModuleInTempDir(t, moduleName, packages)
 
@@ -379,7 +377,7 @@ type Config struct {
 `
 	moduleName := "testunexported"
 	packages := TestModulePackages{
-		".": { {Name: "config.go", Content: content} },
+		".": {{Name: "config.go", Content: content}},
 	}
 	tempModRoot, astFiles, fset := createTestModuleInTempDir(t, moduleName, packages)
 
@@ -400,7 +398,7 @@ func TestAnalyzeOptions_StructNotFound(t *testing.T) {
 	content := `package main; type OtherStruct struct{}`
 	moduleName := "teststructnotfound"
 	packages := TestModulePackages{
-		".": { {Name: "other.go", Content: content} },
+		".": {{Name: "other.go", Content: content}},
 	}
 	tempModRoot, astFiles, fset := createTestModuleInTempDir(t, moduleName, packages)
 
@@ -431,7 +429,7 @@ type ParentConfig struct {
 	AnotherField string
 }`
 	formattedContent1 := fmt.Sprintf(content1, "`env:\"EMBEDDED_STRING\"`", "`env:\"EMBEDDED_INT\"`", "`env:\"PARENT_FIELD\"`")
-	packages1 := TestModulePackages{ ".": { {Name: "config1.go", Content: formattedContent1} } }
+	packages1 := TestModulePackages{".": {{Name: "config1.go", Content: formattedContent1}}}
 	tempModRoot1, astFiles1, fset1 := createTestModuleInTempDir(t, moduleName+"1", packages1)
 
 	targetPackageID1 := moduleName + "1" // moduleName is "testembedded", so "testembedded1"
@@ -517,9 +515,9 @@ type PointerPkgConfig struct { APIKey string ` + "`env:\"API_KEY_TAG\"`" + `}`
 type AnotherExternalEmbedded struct { Token string }`
 
 	packages := TestModulePackages{
-		mainPkgImportSuffix:       { {Name: "main.go", Content: mainContent} },
-		externalPkgImportSuffix:   { {Name: "external.go", Content: externalPkgContent} },
-		anotherPkgImportSuffix:    { {Name: "another.go", Content: anotherPkgContent} },
+		mainPkgImportSuffix:     {{Name: "main.go", Content: mainContent}},
+		externalPkgImportSuffix: {{Name: "external.go", Content: externalPkgContent}},
+		anotherPkgImportSuffix:  {{Name: "another.go", Content: anotherPkgContent}},
 	}
 	tempModRoot, astFiles, fset := createTestModuleInTempDir(t, moduleName, packages)
 
@@ -562,7 +560,7 @@ func TestAnalyzeOptions_ExternalPackageDirectly(t *testing.T) {
 type ExternalConfig struct { ExternalURL string; ExternalRetryCount int }`
 
 	packages := TestModulePackages{
-		pkgSuffix: { {Name: "external.go", Content: externalPkgContent} },
+		pkgSuffix: {{Name: "external.go", Content: externalPkgContent}},
 	}
 	tempModRoot, astFiles, fset := createTestModuleInTempDir(t, moduleName, packages)
 
@@ -596,3 +594,281 @@ type ExternalConfig struct { ExternalURL string; ExternalRetryCount int }`
 // These will need to be reinstated and potentially adjusted once AnalyzeOptionsV2 is fully integrated.
 // Specifically, HelpText might be lost if not properly handled during AST parsing/recreation or if comments are stripped.
 // The focus of this refactoring step is the on-disk module setup.
+
+// --- Tests for AnalyzeOptionsV3 ---
+
+// helperV3_parseTestModulePackages is similar to createTestModuleInTempDir but prepares input for AnalyzeOptionsV3.
+// It returns the FileSet, a map of package import paths to their AST files, and the temp module root (for reference).
+func helperV3_parseTestModulePackages(t *testing.T, moduleName string, packages TestModulePackages) (*token.FileSet, map[string][]*ast.File, string) {
+	t.Helper()
+	tempModRoot, _, fset := createTestModuleInTempDir(t, moduleName, packages) // We leverage the file creation and basic parsing
+
+	// Re-parse or collect ASTs and map them by package import path
+	// For AnalyzeOptionsV3, we need to simulate having parsed files for specific import paths.
+	// The import paths here are relative to the conceptual module structure.
+	parsedPkgFiles := make(map[string][]*ast.File)
+
+	for pkgImportPathSuffix, filesInPkg := range packages {
+		var currentPkgImportPath string
+		if moduleName == "" { // For tests not needing a full module context, pkgImportPathSuffix can be the direct key
+			currentPkgImportPath = pkgImportPathSuffix
+		} else {
+			if pkgImportPathSuffix == "." || pkgImportPathSuffix == "" {
+				currentPkgImportPath = moduleName
+			} else {
+				currentPkgImportPath = moduleName + "/" + pkgImportPathSuffix
+			}
+		}
+
+		var astsForCurrentPkg []*ast.File
+		for _, file := range filesInPkg {
+			var filePath string
+			if pkgImportPathSuffix == "." || pkgImportPathSuffix == "" {
+				filePath = filepath.Join(tempModRoot, file.Name)
+			} else {
+				filePath = filepath.Join(tempModRoot, pkgImportPathSuffix, file.Name)
+			}
+
+			// Parse the file again, or find it in `allAstFilesFromCreate` if that was more convenient.
+			// Parsing here ensures we have distinct ASTs per package if needed, though fset is shared.
+			fileAst, err := parser.ParseFile(fset, filePath, nil, parser.ParseComments|parser.SkipObjectResolution)
+			if err != nil {
+				t.Fatalf("Failed to parse file %s for V3 helper: %v", filePath, err)
+			}
+			astsForCurrentPkg = append(astsForCurrentPkg, fileAst)
+		}
+		parsedPkgFiles[currentPkgImportPath] = astsForCurrentPkg
+	}
+
+	return fset, parsedPkgFiles, tempModRoot
+}
+
+func TestAnalyzeOptionsV3_Simple(t *testing.T) {
+	contentTemplate := `
+package main
+
+// Config holds configuration.
+type Config struct {
+	// Name of the user.
+	Name string %s
+	// Age of the user, optional.
+	Age *int %s
+	// IsAdmin flag.
+	IsAdmin bool %s
+	// Features list.
+	Features []string %s
+}
+`
+	moduleName := "testsimplev3" // Acts as the package import path for this simple case
+
+	testCases := []struct {
+		name            string
+		structName      string
+		tags            []string
+		expectedOptions []*metadata.OptionMetadata
+		targetPkgPath   string // The import path for the package containing the struct
+	}{
+		{
+			name:          "Basic types",
+			structName:    "Config",
+			tags:          []string{"`env:\"APP_NAME\"`", "`env:\"USER_AGE\"`", "", "`env:\"APP_FEATURES\"`"},
+			targetPkgPath: moduleName,
+			expectedOptions: []*metadata.OptionMetadata{
+				// For V3, IsTextUnmarshaler/IsTextMarshaler will be false due to lack of type info
+				{Name: "Name", CliName: "name", TypeName: "string", HelpText: "Name of the user.", IsRequired: true, EnvVar: "APP_NAME", IsTextUnmarshaler: false, IsTextMarshaler: false},
+				{Name: "Age", CliName: "age", TypeName: "*int", HelpText: "Age of the user, optional.", IsPointer: true, IsRequired: false, EnvVar: "USER_AGE", IsTextUnmarshaler: false, IsTextMarshaler: false},
+				{Name: "IsAdmin", CliName: "is-admin", TypeName: "bool", HelpText: "IsAdmin flag.", IsRequired: true, IsTextUnmarshaler: false, IsTextMarshaler: false},
+				{Name: "Features", CliName: "features", TypeName: "[]string", HelpText: "Features list.", IsRequired: true, EnvVar: "APP_FEATURES", IsTextUnmarshaler: false, IsTextMarshaler: false},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var formatArgs []interface{}
+			for _, tag := range tc.tags {
+				formatArgs = append(formatArgs, tag)
+			}
+			formattedContent := fmt.Sprintf(contentTemplate, formatArgs...)
+
+			// For V3, we need to prepare the parsedFiles map.
+			// The package path suffix "." means files are at the root of the conceptual module.
+			// The key in `packages` will be used to form the key in `parsedPkgFiles`.
+			packages := TestModulePackages{
+				".": {{Name: strings.ToLower(tc.structName) + ".go", Content: formattedContent}},
+			}
+			fset, parsedPkgFiles, _ := helperV3_parseTestModulePackages(t, tc.targetPkgPath, packages)
+			// tempModRoot is ignored for V3 as it directly uses parsedPkgFiles
+
+			options, structNameOut, err := AnalyzeOptionsV3(fset, parsedPkgFiles, tc.structName, tc.targetPkgPath, "" /* baseDir not used by V3 yet */)
+			if err != nil {
+				t.Fatalf("AnalyzeOptionsV3 failed for %s: %v. Content:\n%s", tc.name, err, formattedContent)
+			}
+			if structNameOut != tc.structName {
+				t.Errorf("Expected struct name '%s', got '%s' for test %s", tc.structName, structNameOut, tc.name)
+			}
+
+			if len(options) != len(tc.expectedOptions) {
+				t.Fatalf("Expected %d options, got %d for test %s. Options: %+v", len(tc.expectedOptions), len(options), tc.name, options)
+			}
+
+			for j, opt := range options {
+				expectedOpt := tc.expectedOptions[j]
+				if opt.Name != expectedOpt.Name || opt.CliName != expectedOpt.CliName ||
+					opt.TypeName != expectedOpt.TypeName || strings.TrimSpace(opt.HelpText) != strings.TrimSpace(expectedOpt.HelpText) ||
+					opt.IsPointer != expectedOpt.IsPointer || opt.IsRequired != expectedOpt.IsRequired ||
+					opt.EnvVar != expectedOpt.EnvVar ||
+					opt.IsTextUnmarshaler != expectedOpt.IsTextUnmarshaler || // Check these too
+					opt.IsTextMarshaler != expectedOpt.IsTextMarshaler {
+					t.Errorf("Option %d (%s) Mismatch for test %s:\nExpected: %+v\nGot:      %+v", j, opt.Name, tc.name, expectedOpt, opt)
+				}
+			}
+		})
+	}
+}
+
+func TestAnalyzeOptionsV3_WithEmbeddedStructs_SamePackage(t *testing.T) {
+	moduleName := "testembeddedv3" // This will be the package import path
+	content1 := `
+package main
+type EmbeddedConfig struct {
+	EmbeddedString string %s
+	EmbeddedInt *int %s
+}
+type ParentConfig struct {
+	ParentField bool %s
+	EmbeddedConfig
+	AnotherField string
+}`
+	formattedContent1 := fmt.Sprintf(content1, "`env:\"EMBEDDED_STRING\"`", "`env:\"EMBEDDED_INT\"`", "`env:\"PARENT_FIELD\"`")
+
+	packages := TestModulePackages{
+		".": {{Name: "config1.go", Content: formattedContent1}},
+	}
+	fset, parsedPkgFiles, _ := helperV3_parseTestModulePackages(t, moduleName, packages)
+
+	targetPackagePath := moduleName
+	options, structNameOut, err := AnalyzeOptionsV3(fset, parsedPkgFiles, "ParentConfig", targetPackagePath, "")
+	if err != nil {
+		t.Fatalf("AnalyzeOptionsV3 with same-package embedded structs failed: %v. Content:\n%s", err, formattedContent1)
+	}
+
+	expectedOptions := []*metadata.OptionMetadata{
+		{Name: "ParentField", CliName: "parent-field", TypeName: "bool", IsRequired: true, EnvVar: "PARENT_FIELD"},
+		{Name: "EmbeddedString", CliName: "embedded-string", TypeName: "string", IsRequired: true, EnvVar: "EMBEDDED_STRING"},
+		{Name: "EmbeddedInt", CliName: "embedded-int", TypeName: "*int", IsPointer: true, IsRequired: false, EnvVar: "EMBEDDED_INT"},
+		{Name: "AnotherField", CliName: "another-field", TypeName: "string", IsRequired: true},
+	}
+	// Adjust IsTextUnmarshaler/IsTextMarshaler to false for all, as V3 doesn't support type info yet.
+	for _, opt := range expectedOptions {
+		opt.IsTextUnmarshaler = false
+		opt.IsTextMarshaler = false
+	}
+
+	if structNameOut != "ParentConfig" {
+		t.Errorf("Expected struct name 'ParentConfig', got '%s'", structNameOut)
+	}
+	if len(options) != len(expectedOptions) {
+		t.Fatalf("Expected %d options, got %d. Options: %+v", len(expectedOptions), len(options), options)
+	}
+	for i, opt := range options {
+		expectedOpt := expectedOptions[i]
+		if opt.Name != expectedOpt.Name || opt.CliName != expectedOpt.CliName || opt.TypeName != expectedOpt.TypeName ||
+			strings.TrimSpace(opt.HelpText) != strings.TrimSpace(expectedOpt.HelpText) || opt.IsPointer != expectedOpt.IsPointer ||
+			opt.IsRequired != expectedOpt.IsRequired || opt.EnvVar != expectedOpt.EnvVar ||
+			opt.IsTextUnmarshaler != expectedOpt.IsTextUnmarshaler || opt.IsTextMarshaler != expectedOpt.IsTextMarshaler {
+			t.Errorf("Option %d (%s) Mismatch:\nExpected: %+v\nGot:      %+v", i, opt.Name, expectedOpt, opt)
+		}
+	}
+}
+
+func TestAnalyzeOptionsV3_WithExternalPackages_ExpectError(t *testing.T) {
+	mainModuleName := "testexternalv3main"
+	externalModuleName := "testexternalv3ext" // Different "module" for the external package
+
+	mainPkgImportPath := mainModuleName + "/mainpkg"
+	externalPkgImportPath := externalModuleName + "/extpkg"
+
+	mainContent := fmt.Sprintf(`package mainpkg
+import "%s"
+type MainConfig struct {
+    LocalField string
+    extpkg.ExternalEmbedded
+}`, externalPkgImportPath) // This import path won't be resolvable by V3's current stub
+
+	externalContent := `package extpkg
+type ExternalEmbedded struct { ExternalField bool }`
+
+	// Setup for V3: Create ASTs for both packages
+	packages := TestModulePackages{
+		"mainpkg": {{Name: "main.go", Content: mainContent}}, // Suffix for mainModuleName
+	}
+	// We use mainModuleName as the "module context" for parsing main.go
+	fset, parsedPkgFiles, _ := helperV3_parseTestModulePackages(t, mainModuleName, packages)
+
+	// Manually add the external package's AST to simulate it being "available" if V3 knew how to look it up.
+	// For this test, AnalyzeOptionsV3 is expected to fail *because* it doesn't know how to bridge
+	// from `extpkg.ExternalEmbedded` to `externalPkgImportPath`'s ASTs.
+	// So, we don't strictly need externalContent in parsedPkgFiles for *this specific error path*,
+	// but if we were testing successful resolution, we would add it like this:
+	// extPackages := TestModulePackages { "extpkg": { {Name: "external.go", Content: externalContent} } }
+	// _, extParsed, _ := helperV3_parseTestModulePackages(t, externalModuleName, extPackages)
+	// parsedPkgFiles[externalPkgImportPath] = extParsed[externalPkgImportPath] // Add external ASTs
+
+	_, _, err := AnalyzeOptionsV3(fset, parsedPkgFiles, "MainConfig", mainPkgImportPath, "")
+	if err == nil {
+		t.Fatalf("AnalyzeOptionsV3 should have failed for external package embedded struct due to current limitations")
+	}
+
+	// Check current V3 error: "analysis of embedded structs from external packages ('%s') not yet implemented in V3"
+	// The type name in the error will be `extpkg.ExternalEmbedded`.
+	expectedErrorSubstring := "analysis of embedded structs from external packages ('extpkg.ExternalEmbedded') not yet implemented in V3"
+	if !strings.Contains(err.Error(), expectedErrorSubstring) {
+		t.Errorf("Expected error message to contain '%s', but got: %v", expectedErrorSubstring, err)
+	}
+}
+
+func TestAnalyzeOptionsV3_StructNotFound(t *testing.T) {
+	pkgPath := "teststructnotfoundv3"
+	content := `package main; type OtherStruct struct{}`
+
+	packages := TestModulePackages{
+		".": {{Name: "other.go", Content: content}},
+	}
+	fset, parsedPkgFiles, _ := helperV3_parseTestModulePackages(t, pkgPath, packages)
+
+	_, _, err := AnalyzeOptionsV3(fset, parsedPkgFiles, "NonExistentConfig", pkgPath, "")
+	if err == nil {
+		t.Fatal("AnalyzeOptionsV3 should have failed for a non-existent struct")
+	}
+	expectedErrorSubstring := "options struct type 'NonExistentConfig' (simple name 'NonExistentConfig') not found in package"
+	if !strings.Contains(err.Error(), expectedErrorSubstring) {
+		t.Errorf("Expected error message to contain '%s', but got: %v", expectedErrorSubstring, err)
+	}
+}
+
+func TestAnalyzeOptionsV3_UnexportedFields(t *testing.T) {
+	pkgPath := "testunexportedv3"
+	content := `
+package main
+type Config struct {
+	Exported   string
+	unexported string // Should be ignored
+}
+`
+	packages := TestModulePackages{
+		".": {{Name: "config.go", Content: content}},
+	}
+	fset, parsedPkgFiles, _ := helperV3_parseTestModulePackages(t, pkgPath, packages)
+
+	options, _, err := AnalyzeOptionsV3(fset, parsedPkgFiles, "Config", pkgPath, "")
+	if err != nil {
+		t.Fatalf("AnalyzeOptionsV3 failed for UnexportedFields: %v. Content:\n%s", err, content)
+	}
+	if len(options) != 1 {
+		t.Fatalf("Expected 1 option, got %d. Unexported field was not ignored. Options: %+v", len(options), options)
+	}
+	if options[0].Name != "Exported" {
+		t.Errorf("Expected option name 'Exported', got '%s'", options[0].Name)
+	}
+}

--- a/internal/analyzer/run_func_analyzer.go
+++ b/internal/analyzer/run_func_analyzer.go
@@ -45,12 +45,18 @@ func AnalyzeRunFunc(files []*ast.File, funcName string) (*metadata.RunFuncInfo, 
 	// Analyze parameters: expecting `run(options MyOptions) error` or `run(ctx context.Context, options MyOptions) error`
 	params := runFuncDecl.Type.Params.List
 	if len(params) == 1 {
-		if len(params[0].Names) > 0 { info.OptionsArgName = params[0].Names[0].Name }
+		if len(params[0].Names) > 0 {
+			info.OptionsArgName = params[0].Names[0].Name
+		}
 		info.OptionsArgType = astutils.ExprToTypeName(params[0].Type)
 	} else if len(params) == 2 {
-		if len(params[0].Names) > 0 { info.ContextArgName = params[0].Names[0].Name }
+		if len(params[0].Names) > 0 {
+			info.ContextArgName = params[0].Names[0].Name
+		}
 		info.ContextArgType = astutils.ExprToTypeName(params[0].Type)
-		if len(params[1].Names) > 0 { info.OptionsArgName = params[1].Names[0].Name }
+		if len(params[1].Names) > 0 {
+			info.OptionsArgName = params[1].Names[0].Name
+		}
 		info.OptionsArgType = astutils.ExprToTypeName(params[1].Type)
 	} else {
 		return nil, strings.TrimSpace(docComment), fmt.Errorf("function '%s' has unexpected signature: expected 1 or 2 parameters, got %d", funcName, len(params))

--- a/internal/analyzer/testdata/src/example.com/textvar_pkg/textvar_types.go
+++ b/internal/analyzer/testdata/src/example.com/textvar_pkg/textvar_types.go
@@ -40,11 +40,11 @@ func (m MyOnlyMarshaler) MarshalText() ([]byte, error) {
 }
 
 type TextVarOptions struct {
-	FieldA MyTextValue         // Should be Unmarshaler (via *MyTextValue) & Marshaler (via MyTextValue)
-	FieldB *MyPtrTextValue     // Should be Unmarshaler & Marshaler (both via *MyPtrTextValue)
-	FieldC MyPtrTextValue      // Should be Unmarshaler & Marshaler (both via *MyPtrTextValue, on value type)
-	FieldD string              // Standard string, neither
-	FieldE *MyTextValue        // Pointer to type from FieldA
-	FieldF MyOnlyUnmarshaler   // Only Unmarshaler
-	FieldG MyOnlyMarshaler     // Only Marshaler
+	FieldA MyTextValue       // Should be Unmarshaler (via *MyTextValue) & Marshaler (via MyTextValue)
+	FieldB *MyPtrTextValue   // Should be Unmarshaler & Marshaler (both via *MyPtrTextValue)
+	FieldC MyPtrTextValue    // Should be Unmarshaler & Marshaler (both via *MyPtrTextValue, on value type)
+	FieldD string            // Standard string, neither
+	FieldE *MyTextValue      // Pointer to type from FieldA
+	FieldF MyOnlyUnmarshaler // Only Unmarshaler
+	FieldG MyOnlyMarshaler   // Only Marshaler
 }

--- a/internal/analyzer/testdata/src/myexternalpkg/external.go
+++ b/internal/analyzer/testdata/src/myexternalpkg/external.go
@@ -11,11 +11,11 @@ type ExternalConfig struct {
 // ExternalEmbedded holds fields to be embedded from external package.
 type ExternalEmbedded struct {
 	// Flag from external package.
-	IsRemote bool ` + "`env:\"IS_REMOTE_TAG\"`" + `
+	IsRemote bool `env:"IS_REMOTE_TAG"`
 }
 
 // PointerPkgConfig is an external struct often used as a pointer.
 type PointerPkgConfig struct {
 	// APIKey for external service.
-	APIKey string ` + "`env:\"API_KEY_TAG\"`" + `
+	APIKey string `env:"API_KEY_TAG"`
 }

--- a/internal/codegen/main_generator.go
+++ b/internal/codegen/main_generator.go
@@ -320,7 +320,6 @@ func formatHelpText(text string) string {
 	}
 }
 
-
 // GenerateMain creates the Go code string for the new main() function
 // based on the extracted command metadata.
 // If generateFullFile is true, it returns a complete Go file content including package and imports.

--- a/internal/codegen/main_generator_test.go
+++ b/internal/codegen/main_generator_test.go
@@ -847,7 +847,6 @@ func TestGenerateMain_InitializerInMainPackage(t *testing.T) {
 	assertCodeContains(t, actualCode, "err = Run(options)")
 }
 
-
 // New Test Function for formatHelpText
 func TestFormatHelpText(t *testing.T) {
 	tests := []struct {
@@ -888,7 +887,7 @@ func TestFormatHelpText(t *testing.T) {
 		{
 			name:  "pre-existing newline and single quote to backtick",
 			input: "Pre-existing newline\nAnd pre-existing 'backtick'.",
-			want: "`Pre-existing newline\nAnd pre-existing ` + \"`\" + `backtick` + \"`\" + `.`",
+			want:  "`Pre-existing newline\nAnd pre-existing ` + \"`\" + `backtick` + \"`\" + `.`",
 		},
 		{
 			name:  "empty string",

--- a/internal/codegen/writer_test.go
+++ b/internal/codegen/writer_test.go
@@ -3,14 +3,14 @@ package codegen_test
 import (
 	"fmt"
 	"go/ast"
+	"go/format" // Added for format.Source in normalizeCode
 	"go/parser"
 	"go/token"
 	"os"
 	"path/filepath"
-	"regexp" // Added for regexes
+	"regexp"  // Added for regexes
 	"strings" // Added for strings
 	"testing"
-	"go/format" // Added for format.Source in normalizeCode
 
 	"github.com/podhmo/goat/internal/codegen"
 	// Assuming normalizeCode is in the same package or adjust import
@@ -56,6 +56,7 @@ func normalizeCode(t *testing.T, code string) string {
 	// After gofmt, further normalize for robust comparison (remove comments, compact whitespace)
 	return normalizeForContains(string(formatted))
 }
+
 // End of helper functions
 
 // createTempFile creates a temporary Go file with the given initial content.

--- a/internal/help/generator.go
+++ b/internal/help/generator.go
@@ -62,7 +62,7 @@ func generateHelp(w io.Writer, cmdMeta *metadata.CommandMetadata) {
 
 		// Default value printing logic
 		shouldPrintDefault := opt.DefaultValue != nil && opt.DefaultValue != "" // Initial state
-		if strings.HasSuffix(opt.TypeName, "bool") { // Covers "bool" and "*bool"
+		if strings.HasSuffix(opt.TypeName, "bool") {                            // Covers "bool" and "*bool"
 			isDefaultTrue := opt.DefaultValueAsBool() // Correctly handles nil, non-bool, *bool
 			if !isDefaultTrue {
 				// If default is false (or nil for *bool), don't print default.

--- a/internal/interpreter/interpreter.go
+++ b/internal/interpreter/interpreter.go
@@ -114,7 +114,7 @@ func extractMarkerInfo(valueExpr ast.Expr, optMeta *metadata.OptionMetadata, fil
 
 	// Allow original goat path or the one used in cmd/goat tests via testcmdmodule
 	isKnownMarkerPackage := (actualMarkerPkgPath == markerPkgImportPath || // e.g. "github.com/podhmo/goat"
-							 actualMarkerPkgPath == "testcmdmodule/internal/goat") // For cmd/goat tests
+		actualMarkerPkgPath == "testcmdmodule/internal/goat") // For cmd/goat tests
 
 	if !isKnownMarkerPackage {
 		log.Printf("  Call is to package '%s' (alias '%s'), not the recognized marker package(s) ('%s' or 'testcmdmodule/internal/goat')", actualMarkerPkgPath, markerPkgAlias, markerPkgImportPath)

--- a/internal/interpreter/interpreter_test.go
+++ b/internal/interpreter/interpreter_test.go
@@ -188,14 +188,14 @@ func TestInterpretInitializer_InitializerNotFound(t *testing.T) {
 
 func TestInterpretInitializer_FileMarkers(t *testing.T) {
 	tests := []struct {
-		name              string
-		content           string
-		optionsName       string
-		initializerName   string
-		initialOptMeta    []*metadata.OptionMetadata // Input metadata to InterpretInitializer
-		expectedOptMeta   []*metadata.OptionMetadata // Expected metadata after InterpretInitializer
-		expectError       bool
-		expectedErrorMsg  string
+		name             string
+		content          string
+		optionsName      string
+		initializerName  string
+		initialOptMeta   []*metadata.OptionMetadata // Input metadata to InterpretInitializer
+		expectedOptMeta  []*metadata.OptionMetadata // Expected metadata after InterpretInitializer
+		expectError      bool
+		expectedErrorMsg string
 	}{
 		{
 			name: "File with default path only",
@@ -301,7 +301,6 @@ func New() *Config { return &Config{ Input: g.File("in.txt", other.SomeOption())
 				currentOptionsMeta[i] = &metaCopy
 			}
 
-
 			err := InterpretInitializer(fileAst, tt.optionsName, tt.initializerName, currentOptionsMeta, goatPkgImportPath)
 
 			if tt.expectError {
@@ -330,16 +329,25 @@ func New() *Config { return &Config{ Input: g.File("in.txt", other.SomeOption())
 					expectedOpt.CliName = actualOpt.CliName
 				}
 
-
 				if !reflect.DeepEqual(actualOpt, expectedOpt) {
 					t.Errorf("OptionMetadata mismatch for '%s':\nExpected: %+v (type %T)\nActual:   %+v (type %T)",
 						expectedOpt.Name, expectedOpt, expectedOpt, actualOpt, actualOpt)
 					// Detailed field comparison for debugging
-					if actualOpt.Name != expectedOpt.Name {t.Logf(" Name: expected '%s', got '%s'", expectedOpt.Name, actualOpt.Name)}
-					if actualOpt.DefaultValue != expectedOpt.DefaultValue {t.Logf(" DefaultValue: expected '%v', got '%v'", expectedOpt.DefaultValue, actualOpt.DefaultValue)}
-					if actualOpt.TypeName != expectedOpt.TypeName {t.Logf(" TypeName: expected '%s', got '%s'", expectedOpt.TypeName, actualOpt.TypeName)}
-					if actualOpt.FileMustExist != expectedOpt.FileMustExist {t.Logf(" FileMustExist: expected '%t', got '%t'", expectedOpt.FileMustExist, actualOpt.FileMustExist)}
-					if actualOpt.FileGlobPattern != expectedOpt.FileGlobPattern {t.Logf(" FileGlobPattern: expected '%t', got '%t'", expectedOpt.FileGlobPattern, actualOpt.FileGlobPattern)}
+					if actualOpt.Name != expectedOpt.Name {
+						t.Logf(" Name: expected '%s', got '%s'", expectedOpt.Name, actualOpt.Name)
+					}
+					if actualOpt.DefaultValue != expectedOpt.DefaultValue {
+						t.Logf(" DefaultValue: expected '%v', got '%v'", expectedOpt.DefaultValue, actualOpt.DefaultValue)
+					}
+					if actualOpt.TypeName != expectedOpt.TypeName {
+						t.Logf(" TypeName: expected '%s', got '%s'", expectedOpt.TypeName, actualOpt.TypeName)
+					}
+					if actualOpt.FileMustExist != expectedOpt.FileMustExist {
+						t.Logf(" FileMustExist: expected '%t', got '%t'", expectedOpt.FileMustExist, actualOpt.FileMustExist)
+					}
+					if actualOpt.FileGlobPattern != expectedOpt.FileGlobPattern {
+						t.Logf(" FileGlobPattern: expected '%t', got '%t'", expectedOpt.FileGlobPattern, actualOpt.FileGlobPattern)
+					}
 				}
 			}
 		})

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -3,8 +3,8 @@ package loader
 import (
 	"fmt"
 	"go/ast"
-	"go/parser"
 	"go/build"
+	"go/parser"
 	"go/token"
 	"os"
 	"path/filepath"

--- a/internal/metadata/types.go
+++ b/internal/metadata/types.go
@@ -14,30 +14,30 @@ type CommandMetadata struct {
 
 // RunFuncInfo describes the target 'run' function.
 type RunFuncInfo struct {
-	Name           string // Name of the run function (e.g., "run")
-	PackageName    string // Package where the run function is defined
-	OptionsArgName string // Name of the options struct parameter (e.g., "opts")
-	OptionsArgType string // Type name of the options struct (e.g., "Options", "main.Options")
+	Name                       string // Name of the run function (e.g., "run")
+	PackageName                string // Package where the run function is defined
+	OptionsArgName             string // Name of the options struct parameter (e.g., "opts")
+	OptionsArgType             string // Type name of the options struct (e.g., "Options", "main.Options")
 	OptionsArgTypeNameStripped string // Base type name of the options struct (e.g., "Options" from "*Options")
-	OptionsArgIsPointer bool   // True if OptionsArgType is a pointer
-	ContextArgName string // Name of the context.Context parameter (if present)
-	ContextArgType string // Type name of the context.Context parameter (if present)
-	InitializerFunc string // Name of the function that initializes the options struct (e.g., NewOptions)
+	OptionsArgIsPointer        bool   // True if OptionsArgType is a pointer
+	ContextArgName             string // Name of the context.Context parameter (if present)
+	ContextArgType             string // Type name of the context.Context parameter (if present)
+	InitializerFunc            string // Name of the function that initializes the options struct (e.g., NewOptions)
 }
 
 // OptionMetadata holds information about a single command-line option.
 type OptionMetadata struct {
-	Name         string // Original field name in the Options struct (e.g., "UserName")
-	CliName      string // CLI flag name (e.g., "user-name")
-	TypeName     string // Go type of the field (e.g., "string", "*int", "[]string")
-	HelpText     string // Description for the option (from field comment)
-	IsPointer    bool   // True if the field is a pointer type (often implies optional)
-	IsRequired   bool   // True if the option must be provided
-	EnvVar       string // Environment variable name to read from (from `env` tag)
-	DefaultValue any    // Default value (from goat.Default or struct tag)
-	EnumValues   []any  // Allowed enum values (from goat.Enum or struct tag)
+	Name              string // Original field name in the Options struct (e.g., "UserName")
+	CliName           string // CLI flag name (e.g., "user-name")
+	TypeName          string // Go type of the field (e.g., "string", "*int", "[]string")
+	HelpText          string // Description for the option (from field comment)
+	IsPointer         bool   // True if the field is a pointer type (often implies optional)
+	IsRequired        bool   // True if the option must be provided
+	EnvVar            string // Environment variable name to read from (from `env` tag)
+	DefaultValue      any    // Default value (from goat.Default or struct tag)
+	EnumValues        []any  // Allowed enum values (from goat.Enum or struct tag)
 	IsTextUnmarshaler bool   // True if the field's type implements encoding.TextUnmarshaler
-	IsTextMarshaler bool   // True if the field's type implements encoding.TextMarshaler
+	IsTextMarshaler   bool   // True if the field's type implements encoding.TextMarshaler
 
 	// File-specific options
 	FileMustExist   bool `json:"fileMustExist,omitempty"`


### PR DESCRIPTION
This commit introduces a new function `AnalyzeOptionsV3` in the analyzer. This function is an alternative to `AnalyzeOptionsV2` and aims to provide a lazy evaluation mechanism for imports, addressing the eager evaluation behavior of `go/packages` used in `AnalyzeOptionsV2`.

The existing `AnalyzeOptionsV2` function has been preserved.

Key changes:
- Defined `AnalyzeOptionsV3` in `internal/analyzer/options_analyzer.go`.
- Added `TODO` comments in `AnalyzeOptionsV3` for parts that require further implementation, particularly around dynamic package parsing and full type checking.
- Added comprehensive unit tests for `AnalyzeOptionsV3` in `internal/analyzer/options_analyzer_test.go`.