### PR TITLE
feat: Add -analyzer-version flag to select analyzer

### DIFF
--- a/cmd/goat/main.go
+++ b/cmd/goat/main.go
@@ -26,6 +26,7 @@ type Options struct {
 	RunFuncName            string // Name of the target 'run' function (e.g., "run")
 	OptionsInitializerName string // Name of the options initializer function (e.g., "NewOptions")
 	TargetFile             string // Path to the target Go file to be processed
+	AnalyzerVersion        int    // Version of the analyzer to use (2 or 3)
 }
 
 func main() {
@@ -50,9 +51,11 @@ func main() {
 		var (
 			runFuncName            string
 			optionsInitializerName string
+			analyzerVersion        int
 		)
 		emitCmd.StringVar(&runFuncName, "run", "run", "Name of the function to be treated as the entrypoint")
 		emitCmd.StringVar(&optionsInitializerName, "initializer", "", "Name of the function that initializes the options struct")
+		emitCmd.IntVar(&analyzerVersion, "analyzer-version", 2, "Version of the analyzer to use (2 or 3)")
 		// Add usage for emitCmd
 		emitCmd.Usage = func() {
 			fmt.Fprintf(os.Stderr, "Usage: goat emit [options] <target_gofile.go>\n\nOptions:\n")
@@ -71,6 +74,7 @@ func main() {
 			RunFuncName:            runFuncName,
 			OptionsInitializerName: optionsInitializerName,
 			TargetFile:             targetFilename,
+			AnalyzerVersion:        analyzerVersion,
 		}
 		if err := runGoat(opts); err != nil {
 			slog.Error("Error running goat (emit)", "error", err)
@@ -82,9 +86,11 @@ func main() {
 		var (
 			runFuncName            string
 			optionsInitializerName string
+			analyzerVersion        int
 		)
 		helpMessageCmd.StringVar(&runFuncName, "run", "run", "Name of the function to be treated as the entrypoint")
 		helpMessageCmd.StringVar(&optionsInitializerName, "initializer", "", "Name of the function that initializes the options struct")
+		helpMessageCmd.IntVar(&analyzerVersion, "analyzer-version", 2, "Version of the analyzer to use (2 or 3)")
 
 		helpMessageCmd.Usage = func() {
 			fmt.Fprintf(os.Stderr, "Usage: goat help-message [options] <target_gofile.go>\n\nOptions:\n")
@@ -103,6 +109,7 @@ func main() {
 			RunFuncName:            runFuncName,
 			OptionsInitializerName: optionsInitializerName,
 			TargetFile:             targetFilename,
+			AnalyzerVersion:        analyzerVersion,
 		}
 
 		fset := token.NewFileSet()
@@ -120,9 +127,11 @@ func main() {
 		var (
 			runFuncName            string
 			optionsInitializerName string
+			analyzerVersion        int
 		)
 		scanCmd.StringVar(&runFuncName, "run", "run", "Name of the function to be treated as the entrypoint")
 		scanCmd.StringVar(&optionsInitializerName, "initializer", "", "Name of the function that initializes the options struct")
+		scanCmd.IntVar(&analyzerVersion, "analyzer-version", 2, "Version of the analyzer to use (2 or 3)")
 
 		scanCmd.Usage = func() {
 			fmt.Fprintf(os.Stderr, "Usage: goat scan [options] <target_gofile.go>\n\nOptions:\n")
@@ -141,6 +150,7 @@ func main() {
 			RunFuncName:            runFuncName,
 			OptionsInitializerName: optionsInitializerName,
 			TargetFile:             targetFilename,
+			AnalyzerVersion:        analyzerVersion,
 		}
 
 		fset := token.NewFileSet()
@@ -290,7 +300,7 @@ func scanMain(fset *token.FileSet, opts *Options) (*metadata.CommandMetadata, *a
 	// If moduleName is empty and targetPackageID is ".", it implies a simple dir-based package.
 	// currentPackageName (the Go `package foo` name) is used by AnalyzeOptionsV2 for struct lookup within the package.
 
-	cmdMetadata, returnedOptionsStructName, err := analyzer.Analyze(fset, finalFilesForAnalysis, opts.RunFuncName, targetPackageID, moduleRootPath)
+	cmdMetadata, returnedOptionsStructName, err := analyzer.Analyze(fset, finalFilesForAnalysis, opts.RunFuncName, targetPackageID, moduleRootPath, opts.AnalyzerVersion)
 	if err != nil {
 		return nil, targetFileAst, fmt.Errorf("failed to analyze AST (targetPkgID: %s, modRoot: %s): %w", targetPackageID, moduleRootPath, err)
 	}

--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -197,7 +197,8 @@ func main() { RunWithoutOptions(nil) }
 			}
 
 			// targetPackageID for Analyze should match the package declaration in the source.
-			cmdMeta, _, err := Analyze(fset, astFiles, tc.runFuncName, tc.packageName, moduleRootDir)
+			// Existing tests implicitly test V2 behavior.
+			cmdMeta, _, err := Analyze(fset, astFiles, tc.runFuncName, tc.packageName, moduleRootDir, 2)
 
 			// InitializerFunc is determined before AnalyzeOptionsV2 is called.
 			// So, we should be able to check it even if Analyze later returns an error from AnalyzeOptionsV2.


### PR DESCRIPTION
This commit introduces a new command-line flag `-analyzer-version` to the `goat` tool, allowing you to choose between analyzer v2 and v3.

The flag is available for the `emit`, `help-message`, and `scan` subcommands.
- `-analyzer-version=2` (default): Uses the existing V2 analyzer (`AnalyzeOptionsV2`), which leverages `go/packages`.
- `-analyzer-version=3`: Uses the newer V3 analyzer (`AnalyzeOptionsV3`), which aims to parse ASTs directly without `go/packages` for potentially better performance, but currently has limitations (e.g., `IsTextUnmarshaler` detection).

Changes include:
- Added the `-analyzer-version` flag to `cmd/goat/main.go`.
- Modified `Options` struct and `scanMain` to propagate the version.
- Updated `internal/analyzer/analyzer.go` to dispatch to the selected analyzer version.
- Added tests in `cmd/goat/main_test.go` to verify the flag's functionality by checking differences in output metadata (specifically `IsTextUnmarshaler`) between V2 and V3.