### PR TITLE
Use go tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ examples-emit:
 # format the code
 # need: go install golang.org/x/tools/cmd/goimports@latest
 format:
-	goimports -w $(shell find . -name '*.go' -not -path './vendor/*' -not -path './.git/*')
+	go tool goimports -w $(shell find . -name '*.go' -not -path './vendor/*' -not -path './.git/*')
 .PHONY: format
 
 test:

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,5 +1,7 @@
 module github.com/podhmo/goat/examples
 
-go 1.21
+go 1.24
+
+tool golang.org/x/tools/cmd/goimports
 
 replace github.com/podhmo/goat => ../

--- a/go.mod
+++ b/go.mod
@@ -1,17 +1,17 @@
 module github.com/podhmo/goat
 
-// tool golang.org/x/tools/cmd/goimports
-go 1.23.0
+go 1.24.0
 
-toolchain go1.23.9
+tool golang.org/x/tools/cmd/goimports
 
-require golang.org/x/tools v0.33.0
+require golang.org/x/tools v0.34.0
 
 require (
-	golang.org/x/mod v0.24.0 // indirect
-	golang.org/x/sync v0.14.0 // indirect
+	golang.org/x/mod v0.25.0 // indirect
+	golang.org/x/sync v0.15.0 // indirect
 )
 
+// for test
 replace example.com/myexternalpkg => ./internal/analyzer/testdata/src/myexternalpkg
 
 replace example.com/anotherpkg => ./internal/analyzer/testdata/src/anotherpkg

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-golang.org/x/mod v0.24.0 h1:ZfthKaKaT4NrhGVZHO1/WDTwGES4De8KtWO0SIbNJMU=
-golang.org/x/mod v0.24.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=
-golang.org/x/sync v0.14.0 h1:woo0S4Yywslg6hp4eUFjTVOyKt0RookbpAHG4c1HmhQ=
-golang.org/x/sync v0.14.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
-golang.org/x/tools v0.33.0 h1:4qz2S3zmRxbGIhDIAgjxvFutSvH5EfnsYrRBj0UI0bc=
-golang.org/x/tools v0.33.0/go.mod h1:CIJMaWEY88juyUfo7UbgPqbC8rU2OqfAV1h2Qp0oMYI=
+golang.org/x/mod v0.25.0 h1:n7a+ZbQKQA/Ysbyb0/6IbB1H/X41mKgbhfv7AfG/44w=
+golang.org/x/mod v0.25.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=
+golang.org/x/sync v0.15.0 h1:KWH3jNZsfyT6xfAfKiz6MRNmd46ByHDYaZ7KSkCtdW8=
+golang.org/x/sync v0.15.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
+golang.org/x/tools v0.34.0 h1:qIpSLOxeCYGg9TrcJokLBG4KFA6d795g0xkBkiESGlo=
+golang.org/x/tools v0.34.0/go.mod h1:pAP9OwEaY1CAW3HOmg3hLZC5Z0CCmzjAF2UQMSqNARg=

--- a/internal/analyzer/options_analyzer_test.go
+++ b/internal/analyzer/options_analyzer_test.go
@@ -767,7 +767,6 @@ type ParentConfig struct {
 	fset, parsedPkgFiles, tempModRoot := helperV3_parseTestModulePackages(t, moduleName, packages)
 	t.Logf("Test module for TestAnalyzeOptionsV3_WithEmbeddedStructs_SamePackage created at: %s", tempModRoot)
 
-
 	targetPackagePath := moduleName // Since files are in the "root" of this conceptual module
 	options, structNameOut, err := AnalyzeOptionsV3(fset, parsedPkgFiles, "ParentConfig", targetPackagePath, "")
 	if err != nil {


### PR DESCRIPTION
This pull request includes updates to Go module dependencies, tooling configurations, and minor code adjustments. The most significant changes involve upgrading the Go version and dependencies, adding tooling references, and refining the `Makefile` for formatting commands.

### Go module and dependency updates:

* [`examples/go.mod`](diffhunk://#diff-cd249c062d77b4d6a5621756423850d0708ffbe4aae554ce33cdc5b908b0ee39L3-R5): Upgraded the Go version from `1.21` to `1.24` and added a reference to the `golang.org/x/tools/cmd/goimports` tool.
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R14): Updated the Go version from `1.23.0` to `1.24.0`, added a reference to `golang.org/x/tools/cmd/goimports`, upgraded `golang.org/x/tools` to `v0.34.0`, and incremented versions of indirect dependencies (`golang.org/x/mod` and `golang.org/x/sync`).

### Tooling and formatting improvements:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L15-R15): Updated the `format` target to explicitly use `go tool goimports` instead of just `goimports`. This ensures compatibility with the Go toolchain.

### Minor code cleanup:

* [`internal/analyzer/options_analyzer_test.go`](diffhunk://#diff-f9d4849ebd778f74c3437c770691bb3a8e195629c0ae3af72d483ddb8df7405eL770): Removed an unnecessary blank line in the test setup for `ParentConfig`.