### PR TITLE
feat: shared fset in lazyload

### DIFF
--- a/internal/loader/lazyload/loader_test.go
+++ b/internal/loader/lazyload/loader_test.go
@@ -2,7 +2,7 @@ package lazyload
 
 import (
 	"fmt"
-	"go/ast" // Ensure this is present and uncommented
+	"go/ast"
 	"go/parser"
 	"go/token"
 	"os"

--- a/internal/loader/lazyload/package.go
+++ b/internal/loader/lazyload/package.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"go/ast"
 	"go/parser"
-	"go/token"
 	"path/filepath"
 	"strconv"
 	"sync"
@@ -56,7 +55,7 @@ func NewPackage(meta PackageMetaInfo, loader *Loader) *Package {
 // It populates p.parsedFiles and p.fileImports.
 func (p *Package) ensureParsed() error {
 	p.parseOnce.Do(func() {
-		fset := token.NewFileSet() // One fset per package for now
+		fset := p.loader.fset // Use the loader's file set
 		for _, goFile := range p.GoFiles {
 			path := filepath.Join(p.Dir, goFile)
 			// fileAST, err := parser.ParseFile(fset, path, nil, parser.ImportsOnly|parser.ParseComments) // Initially parse imports for quick access, then full parse on demand for GetStruct etc.


### PR DESCRIPTION
This pull request introduces changes to centralize and reuse the `token.FileSet` (`fset`) across the lazy loading package, improving memory efficiency and consistency. The changes include modifications to the `Loader` and `Package` structures, as well as their initialization and usage of `fset`.

### Enhancements to `token.FileSet` management:

* [`internal/loader/lazyload/loader.go`](diffhunk://#diff-d9b3a105a44e1c366500d88fe77041a755713906146c7dfb1cbe3c110d44c4f6R22-R25): Added a `Fset` field to the `Config` struct and a corresponding `fset` field to the `Loader` struct. Updated the `NewLoader` function to initialize `fset` from the configuration or create a new one if not provided. This ensures a shared `FileSet` is used across the loader. [[1]](diffhunk://#diff-d9b3a105a44e1c366500d88fe77041a755713906146c7dfb1cbe3c110d44c4f6R22-R25) [[2]](diffhunk://#diff-d9b3a105a44e1c366500d88fe77041a755713906146c7dfb1cbe3c110d44c4f6R34) [[3]](diffhunk://#diff-d9b3a105a44e1c366500d88fe77041a755713906146c7dfb1cbe3c110d44c4f6R45-R50)

* [`internal/loader/lazyload/package.go`](diffhunk://#diff-01ab65a0e1f73280066c46ce0b66050f1a46c8d4c58b438746ea3d364916dfeaL59-R58): Updated the `ensureParsed` method in the `Package` struct to use the shared `fset` from the `Loader` instead of creating a new `FileSet` for each package. This reduces redundant memory allocations.

### Code cleanup and consistency:

* [`internal/loader/lazyload/loader.go`](diffhunk://#diff-d9b3a105a44e1c366500d88fe77041a755713906146c7dfb1cbe3c110d44c4f6R5): Added the `token` package import to support the `Fset` changes in the `Loader` and `Config` structs.

* [`internal/loader/lazyload/loader_test.go`](diffhunk://#diff-0f09233263f6d6f4407cc94a5a70314121bfc02b8c3f7342f415d7705713802bL5-R5): Updated imports to ensure `go/ast` is uncommented and consistent with other changes.

* [`internal/loader/lazyload/package.go`](diffhunk://#diff-01ab65a0e1f73280066c46ce0b66050f1a46c8d4c58b438746ea3d364916dfeaL7): Removed the unused `go/token` import as the `FileSet` is now managed by the `Loader`.