### PR TITLE
Fix: Correct test failures due to loader refactoring

### DIFF
--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -57,4 +57,9 @@ To simplify package structure and naming conventions, the package for lazy loadi
 -   **Constructor**: The constructor function is `loader.New`.
 
 This restructuring streamlines access to the loader functionality. The core lazy-loading strategy remains consistent.
+
+## Refactoring and Renaming in `internal/loader`
+
+- The package `internal/loader/lazyload` was consolidated into the `internal/loader` package. This change necessitated updates to import statements in files that previously imported `lazyload`.
+- The constructor function `loader.NewLoader` within the `internal/loader` package was renamed to `loader.New`. All instances where `NewLoader` was called needed to be updated to use `New`.
 [end of docs/knowledge.md]

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -7,7 +7,7 @@ import (
 	"log/slog"
 	"strings" // Added import
 
-	"github.com/podhmo/goat/internal/loader/lazyload" // Added import for lazyload.Config
+	"github.com/podhmo/goat/internal/loader" // Changed import for lazyload.Config
 	"github.com/podhmo/goat/internal/metadata"
 )
 
@@ -18,7 +18,7 @@ import (
 // - targetPackageID: Import path of the package containing the runFuncName (e.g., "testmodule/example.com/mainpkg").
 // - moduleRootPath: Absolute path to the root of the module this package belongs to.
 // - loader: Loader for lazy loading of package information.
-func Analyze(fset *token.FileSet, files []*ast.File, runFuncName string, targetPackageID string, moduleRootPath string, loader *lazyload.Loader) (*metadata.CommandMetadata, string, error) {
+func Analyze(fset *token.FileSet, files []*ast.File, runFuncName string, targetPackageID string, moduleRootPath string, loader *loader.Loader) (*metadata.CommandMetadata, string, error) {
 	cmdMeta := &metadata.CommandMetadata{
 		Options: []*metadata.OptionMetadata{},
 	}
@@ -109,10 +109,10 @@ func Analyze(fset *token.FileSet, files []*ast.File, runFuncName string, targetP
 		// err is already declared in the function scope from AnalyzeRunFunc, reuse it.
 
 		slog.Debug("Goat: Analyzing options", "targetPackageID", targetPackageID, "moduleRootPath", moduleRootPath)
-		// AnalyzeOptions uses the lazyload package for dynamic parsing and type analysis.
+		// AnalyzeOptions uses the loader package for dynamic parsing and type analysis.
 		// It no longer requires a map of pre-parsed AST files.
-		// The loader instance (which is assumed to be *lazyload.Config) is passed directly.
-		options, foundOptionsStructName, err = AnalyzeOptions(fset, runFuncInfo.OptionsArgType, targetPackageID, moduleRootPath, loader) // loader is *lazyload.Config
+		// The loader instance (which is assumed to be *loader.Config) is passed directly.
+		options, foundOptionsStructName, err = AnalyzeOptions(fset, runFuncInfo.OptionsArgType, targetPackageID, moduleRootPath, loader) // loader is *loader.Config
 
 		if err != nil {
 			return nil, "", fmt.Errorf("analyzing options struct for run function '%s' in package '%s': %w", runFuncName, targetPackageID, err)

--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/podhmo/goat/internal/loader/lazyload" // Added
+	"github.com/podhmo/goat/internal/loader" // Changed
 	// "strings" // No longer used directly in the simplified parseTestFiles
 	// "golang.org/x/tools/go/packages" // No longer used in the simplified parseTestFiles
 )
@@ -202,8 +202,8 @@ func main() { RunWithoutOptions(nil) }
 			// So the import path is "testmodule". tc.packageName is the `package foo` name.
 			targetPackageID := "testmodule" // Module name defined in parseTestFiles
 
-			llCfg := lazyload.Config{Fset: fset} // Removed BaseDir from here
-			loader := lazyload.NewLoader(llCfg)
+			llCfg := loader.Config{Fset: fset} // Removed BaseDir from here
+			loader := loader.New(llCfg)
 			cmdMeta, _, err := Analyze(fset, astFiles, tc.runFuncName, targetPackageID, moduleRootDir, loader)
 
 			// InitializerFunc is determined before AnalyzeOptions is called.

--- a/internal/analyzer/options_analyzer.go
+++ b/internal/analyzer/options_analyzer.go
@@ -16,7 +16,7 @@ import (
 	// No longer need "bytes" or "go/format" for overlay population from ASTs
 	// "golang.org/x/tools/go/packages" // Removed unused import
 
-	"github.com/podhmo/goat/internal/loader/lazyload"
+	"github.com/podhmo/goat/internal/loader" // Changed
 	"github.com/podhmo/goat/internal/metadata"
 	"github.com/podhmo/goat/internal/utils/astutils"
 	"github.com/podhmo/goat/internal/utils/stringutils"
@@ -69,13 +69,13 @@ func init() {
 //   - optionsTypeName: Name of the options struct type (e.g., "MainConfig").
 //   - targetPackagePath: The import path of the package containing optionsTypeName.
 //   - baseDir: The base directory from which to resolve targetPackagePath (often module root).
-//   - loader: Instance of lazyload.Loader.
+//   - loader: Instance of loader.Loader.
 func AnalyzeOptions( // Renamed from AnalyzeOptionsV3
 	fset *token.FileSet, // Still needed for some astutils
 	optionsTypeName string,
 	targetPackagePath string,
 	baseDir string,
-	loader *lazyload.Loader, // Changed from llConfig *lazyload.Config
+	loader *loader.Loader, // Changed from llConfig *loader.Config
 ) ([]*metadata.OptionMetadata, string, error) {
 	// Heuristic adjustment for loadPattern based on typical test setups.
 	// If targetPackagePath is simple (no slashes, e.g., a module name) and baseDir is set,
@@ -94,10 +94,10 @@ func AnalyzeOptions( // Renamed from AnalyzeOptionsV3
 
 	loadedPkgs, err := loader.Load(loadPattern, baseDir) // Use the passed-in loader
 	if err != nil {
-		return nil, "", fmt.Errorf("error loading package '%s' (pattern '%s', baseDir '%s') with lazyload: %w", targetPackagePath, loadPattern, baseDir, err)
+		return nil, "", fmt.Errorf("error loading package '%s' (pattern '%s', baseDir '%s') with loader: %w", targetPackagePath, loadPattern, baseDir, err)
 	}
 	if len(loadedPkgs) == 0 {
-		return nil, "", fmt.Errorf("no package found for '%s' (pattern '%s', baseDir '%s') by lazyload", targetPackagePath, loadPattern, baseDir)
+		return nil, "", fmt.Errorf("no package found for '%s' (pattern '%s', baseDir '%s') by loader", targetPackagePath, loadPattern, baseDir)
 	}
 	currentPkg := loadedPkgs[0]
 


### PR DESCRIPTION
This commit addresses test failures caused by recent refactoring within the internal/loader package.

The following changes were made:
- Updated import paths for the `lazyload` package, which was moved into the `loader` package. This affected `internal/analyzer/analyzer.go`, `cmd/goat/main.go`, and their respective test files.
- Renamed `loader.NewLoader` to `loader.New` in all files where it was used, reflecting the change in `internal/loader/loader.go`.

All tests now pass after these corrections. Code has also been formatted according to project standards.