### PR TITLE
feat: Parse only main.go AST initially and defer other loading

### DIFF
--- a/examples/hello/main.go
+++ b/examples/hello/main.go
@@ -20,10 +20,10 @@ func main() {
 	isFlagExplicitlySet := make(map[string]bool)
 
 	flag.Usage = func() {
-		fmt.Fprint(os.Stderr, `m/hello - run is the actual command logic.
+		fmt.Fprint(os.Stderr, `github.com/podhmo/goat/examples/hello - run is the actual command logic.
 
 Usage:
-  m/hello [flags]
+  github.com/podhmo/goat/examples/hello [flags]
 
 Flags:
   --version     bool     Print version information

--- a/internal/analyzer/options_analyzer.go
+++ b/internal/analyzer/options_analyzer.go
@@ -92,12 +92,14 @@ func AnalyzeOptions( // Renamed from AnalyzeOptionsV3
 
 	// loader is now passed in directly
 
-	loadedPkgs, err := loader.Load(loadPattern, baseDir) // Use the passed-in loader
+	loadedPkgs, err := loader.Load(loadPattern) // Use the passed-in loader. baseDir is handled by the locator if necessary.
 	if err != nil {
-		return nil, "", fmt.Errorf("error loading package '%s' (pattern '%s', baseDir '%s') with loader: %w", targetPackagePath, loadPattern, baseDir, err)
+		// Updated error message to reflect that baseDir is not directly used by Load() here.
+		return nil, "", fmt.Errorf("error loading package '%s' (derived load pattern '%s') with loader: %w", targetPackagePath, loadPattern, err)
 	}
 	if len(loadedPkgs) == 0 {
-		return nil, "", fmt.Errorf("no package found for '%s' (pattern '%s', baseDir '%s') by loader", targetPackagePath, loadPattern, baseDir)
+		// Updated error message
+		return nil, "", fmt.Errorf("no package found for '%s' (derived load pattern '%s') by loader", targetPackagePath, loadPattern)
 	}
 	currentPkg := loadedPkgs[0]
 


### PR DESCRIPTION
Modifies `cmd/goat/main.go` to initially parse only the AST of the target Go file specified in the command-line arguments. Previously, it would load all files in the target package.

The `internal/analyzer` package will now rely on the `loader.Loader` instance to fetch type information for entities not present in the initially parsed main.go AST, such as options structs defined in other files or packages. This aligns with the requirement to defer loading of package contents until necessary.

- `cmd/goat/main.go#scanMain`:
    - Changed to use `parser.ParseFile()` for the target file.
    - Still uses `loader.Load(".")` on the target directory to get the canonical package import path and directory for module root discovery.
- `internal/analyzer/analyzer.go`:
    - No structural changes were needed as `AnalyzeOptions` already utilized the loader. The change in input (single AST) means the loader's role in fetching external/other-file definitions becomes more prominent.
    - Confirmed `AnalyzeRunFunc` and main function position logic are compatible as they operate on the provided main AST.

This change optimizes initial processing by focusing only on the specified main file, deferring broader package analysis until explicitly required by type resolution within the analyzer.