### PR TITLE
Refactor: Clarify usage of modfile package in loader

### DIFF
--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -81,3 +81,10 @@ This function:
 - When the import path refers to the root of an external dependency module.
 
 This change ensures more accurate package metadata collection, which is crucial for dependent tools and analysis.
+
+## Clarifying Existing Library Usage
+
+- **Issue Context**: A request was made to use `golang.org/x/mod/modfile` for parsing `go.mod` files in `internal/loader`.
+- **Resolution**: Investigation revealed that `internal/loader/locator.go` (specifically the `GoModLocator`) already utilized this library for `go.mod` parsing via the `parseGoMod` function.
+- **Action Taken**: A clarifying comment was added to the `parseGoMod` function to make this usage explicit. This helps in confirming adherence to such requirements if the codebase is audited or reviewed for specific library uses.
+- **Learning**: When an issue requests the use of a specific library or technique, first thoroughly verify its current usage. If already implemented, clarification (e.g., via comments or documentation updates) might be the appropriate resolution, rather than assuming a missing implementation. This ensures that the intent of the issue (confirming best practices or specific dependencies) is met.

--- a/internal/loader/locator.go
+++ b/internal/loader/locator.go
@@ -305,7 +305,7 @@ func (gml *GoModLocator) Locate(pattern string, buildCtx BuildContext) ([]Packag
 	return nil, fmt.Errorf("GoModLocator: package %q not found by any method (relative, in-module, or go.mod dependency)", pattern)
 }
 
-// parseGoMod reads and parses a go.mod file.
+// parseGoMod reads and parses a go.mod file using the golang.org/x/mod/modfile package.
 func (gml *GoModLocator) parseGoMod(modFilePath string) (*modfile.File, error) {
 	data, err := os.ReadFile(modFilePath)
 	if err != nil {


### PR DESCRIPTION
The internal/loader/locator.go component, specifically within the GoModLocator's parseGoMod function, already utilizes the golang.org/x/mod/modfile package for parsing go.mod files.

This commit adds an explicit comment to the parseGoMod function to make this existing usage clear, addressing the issue requesting the use of said library.

Additionally, relevant learnings from this clarification have been documented in docs/knowledge.md.