### PR TITLE
Fix: Improve GoModLocator robustness

### DIFF
--- a/cmd/goat/main_test.go
+++ b/cmd/goat/main_test.go
@@ -7,7 +7,7 @@ import (
 	"go/token"
 	"io"
 	"os"
-	"os/exec" // Added for go mod tidy
+	"os/exec"       // Added for go mod tidy
 	"path/filepath" // Added for filepath.Join
 	"strings"
 	"testing"

--- a/internal/loader/locator.go
+++ b/internal/loader/locator.go
@@ -91,13 +91,20 @@ type GoModLocator struct {
 // Locate implements the PackageLocator interface for GoModLocator.
 // It resolves package paths without using `go list`.
 func (gml *GoModLocator) Locate(pattern string, buildCtx BuildContext) ([]PackageMetaInfo, error) {
+	if gml.workingDir == "" {
+		wd, err := os.Getwd()
+		if err != nil {
+			return nil, fmt.Errorf("GoModLocator.Locate: failed to get current working directory: %w", err)
+		}
+		gml.workingDir = wd
+	}
 	var pkgName string // Declare pkgName
 	// Handle vendor paths (placeholder)
 	if strings.Contains(pattern, "/vendor/") || strings.HasPrefix(pattern, "vendor/") {
 		return nil, errors.New("GoModLocator.Locate: vendor directory handling is not yet implemented")
 	}
 
-	if strings.HasPrefix(pattern, "./") || strings.HasPrefix(pattern, "../") {
+	if pattern == "." || strings.HasPrefix(pattern, "./") || strings.HasPrefix(pattern, "../") {
 		// Handle relative path
 		pkgDir := filepath.Clean(filepath.Join(gml.workingDir, pattern))
 		absPkgDir, err := filepath.Abs(pkgDir) // Ensure pkgDir is absolute


### PR DESCRIPTION
This commit addresses potential issues in `internal/loader/locator.go`:

- The `GoModLocator.workingDir` field is now initialized with the current working directory (`os.Getwd()`) at the beginning of the `Locate` method if it's not already set. This ensures that subsequent operations like `findModuleRoot` have a valid base directory.
- The relative path detection logic in `Locate` has been updated to explicitly handle the `pattern == "."` case. Previously, this case was not covered by `strings.HasPrefix`, potentially leading to incorrect package resolution for the current directory.

These changes enhance the reliability of the `gomod` locator, particularly when locating packages using the "." pattern. I've confirmed that tests continue to pass after these modifications.