### PR TITLE
I applied auto-formatting to the codebase.

### DIFF
--- a/internal/analyzer/analyzer_test.go
+++ b/internal/analyzer/analyzer_test.go
@@ -4,10 +4,10 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"testing"
-	"log/slog"
 
 	"github.com/podhmo/goat/internal/loader" // Changed
 	// "strings" // No longer used directly in the simplified parseTestFiles


### PR DESCRIPTION
I ran `make format` to apply standard Go formatting to the project files. Then, I ran `make test` to ensure no compilation errors were introduced; all tests passed.