### PR TITLE
Fix: Correct import paths to resolve test failures

### DIFF
--- a/cmd/goat/main.go
+++ b/cmd/goat/main.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/podhmo/goat/internal/analyzer"
 	"github.com/podhmo/goat/internal/codegen"
-	"github.com/podhmo/goat/internal/help"
+	help "github.com/podhmo/goat/internal/helpgen"
 	"github.com/podhmo/goat/internal/interpreter"
 	"github.com/podhmo/goat/internal/loader"
 	"github.com/podhmo/goat/internal/metadata"

--- a/cmd/goat/main_test.go
+++ b/cmd/goat/main_test.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/podhmo/goat/internal/help"
+	help "github.com/podhmo/goat/internal/helpgen"
 	"github.com/podhmo/goat/internal/metadata"
 )
 


### PR DESCRIPTION
The tests were failing due to incorrect import paths for an internal package. The `internal/help` package had been renamed or moved to `internal/helpgen`.

This commit updates the import paths in `cmd/goat/main.go` and `cmd/goat/main_test.go` to correctly point to `internal/helpgen`, using an alias `help` to minimize code changes.

After these changes, the tests pass successfully.
The code has also been formatted.