### PR TITLE
Fix: Resolve enum values correctly in interpreter

### DIFF
--- a/internal/analyzer/options_analyzer.go
+++ b/internal/analyzer/options_analyzer.go
@@ -329,6 +329,20 @@ func AnalyzeOptions( // Renamed from AnalyzeOptionsV3
 				}
 				opt.HelpText += strings.TrimSpace(fieldASTNode.Comment.Text())
 			}
+			opt.HelpText = strings.TrimSpace(opt.HelpText) // From AST comments
+
+			// Populate HelpText from struct tag "comment" or "description"
+			// Tag value overrides AST comments if present.
+			tagComment := fieldInfo.GetTag("comment")
+			if tagComment != "" {
+				opt.HelpText = tagComment
+			} else {
+				tagDescription := fieldInfo.GetTag("description")
+				if tagDescription != "" {
+					opt.HelpText = tagDescription
+				}
+			}
+			// Ensure HelpText is trimmed one last time after potentially using tags
 			opt.HelpText = strings.TrimSpace(opt.HelpText)
 		}
 


### PR DESCRIPTION
This commit addresses issues in internal/interpreter where enum values, especially those defined as constants (local or imported) or via string casts, were not being resolved correctly.

Key changes:
- Modified `internal/interpreter/interpreter.go`:
    - `resolveEvalResultToEnumString` now correctly looks up constants, handles string casts (e.g., `const C = string(OtherConst)`), and resolves qualified identifiers using the correct file context for package alias resolution.
    - `extractEnumValuesFromEvalResult` now correctly resolves elements within composite literals (e.g., `[]MyEnum{pkg.ValA, localValB}`), passing the correct definition file context for resolving identifiers.
    - Enabled resolution for enum values passed as direct identifiers to `goat.Default(val, EnumSliceVar)`.
- Modified `internal/analyzer/options_analyzer.go`:
    - Option help text (description) is now preferentially sourced from `comment:"..."` or `description:"..."` struct tags, falling back to AST comments.
- Added `TestHelpMessageWithEnums` to `cmd/goat/main_test.go`:
    - This test verifies that help messages for enum fields correctly display their description, allowed values, and default values.
    - The test's enum constants are defined individually (e.g., `const ValA = "a"`) as a temporary workaround for a separate issue identified in `internal/loader` where grouped constants (e.g., `const (ValA="a"; ValB="b")`) are not correctly resolved by `loader.LookupSymbol`. This loader issue will be addressed separately.

All tests pass with these changes, including the new enum help message test (with the workaround).