### PR TITLE
Fix: Ensure pointer flags are nil if not set

### DIFF
--- a/examples/enum/main.go
+++ b/examples/enum/main.go
@@ -136,6 +136,8 @@ imported from another package.`)
 	flag.Parse()
 	flag.Visit(func(f *flag.Flag) { isFlagExplicitlySet[f.Name] = true })
 
+	// 6. Assign values for initially nil pointers if flags were explicitly set
+
 	// 5. Perform required checks (excluding booleans).
 
 	isValidChoice_LocalEnumField := false

--- a/examples/fullset/main.go
+++ b/examples/fullset/main.go
@@ -250,41 +250,50 @@ Flags:
 
 	// 3. Set flags.
 	flag.StringVar(&options.Name, "name", options.Name, "Name of the person to greet. This is a mandatory field." /* Original Default: World, Env: SIMPLE_NAME */)
+	isAgeNilInitially := options.Age == nil
+	var tempAgeVal int
 	var defaultAgeValForFlag int
 	if options.Age != nil {
 		defaultAgeValForFlag = *options.Age
 	}
-	if options.Age == nil {
-		options.Age = new(int)
+	if isAgeNilInitially {
+		flag.IntVar(&tempAgeVal, "age", 0, "Age of the person. This is an optional field." /* Env: SIMPLE_AGE */)
+	} else {
+		flag.IntVar(options.Age, "age", defaultAgeValForFlag, "Age of the person. This is an optional field." /* Env: SIMPLE_AGE */)
 	}
-	flag.IntVar(options.Age, "age", defaultAgeValForFlag, "Age of the person. This is an optional field." /* Env: SIMPLE_AGE */)
 	flag.StringVar(&options.LogLevel, "log-level", options.LogLevel, `LogLevel for the application output.
 It can be one of: debug, info, warning, error.` /* Original Default: info, Env: SIMPLE_LOG_LEVEL */)
 	flag.StringVar(&options.OutputDir, "output-dir", options.OutputDir, `OutputDir for any generated files or reports.
 Defaults to "output" if not specified by the user.` /* Original Default: output, Env:  */)
 	flag.StringVar(&options.Mode, "mode", options.Mode, "Mode of operation for the tool, affecting its behavior." /* Original Default: standard, Env: SIMPLE_MODE */)
 	flag.BoolVar(&options.SuperVerbose, "super-verbose", options.SuperVerbose, "Enable extra verbose output." /* Env: SIMPLE_SUPER_VERBOSE */)
+	isOptionalToggleNilInitially := options.OptionalToggle == nil
+	var tempOptionalToggleVal bool
 	var defaultOptionalToggleValForFlag bool
 	if options.OptionalToggle != nil {
 		defaultOptionalToggleValForFlag = *options.OptionalToggle
 	}
-	if options.OptionalToggle == nil {
-		options.OptionalToggle = new(bool)
+	if isOptionalToggleNilInitially {
+		flag.BoolVar(&tempOptionalToggleVal, "optional-toggle", false, "An optional boolean flag with no default, should be nil if not set.")
+	} else {
+		flag.BoolVar(options.OptionalToggle, "optional-toggle", defaultOptionalToggleValForFlag, "An optional boolean flag with no default, should be nil if not set.")
 	}
-	flag.BoolVar(options.OptionalToggle, "optional-toggle", defaultOptionalToggleValForFlag, "An optional boolean flag with no default, should be nil if not set.")
 	flag.StringVar(&options.ConfigFile, "config-file", options.ConfigFile, "Path to a configuration file. Must exist. (env:\"FULLSET_CONFIG_FILE\")" /* Original Default: config.json, Env: FULLSET_CONFIG_FILE */)
 	flag.StringVar(&options.Pattern, "pattern", options.Pattern, "A glob pattern for input files. (env:\"FULLSET_PATTERN\")" /* Original Default: *.go, Env: FULLSET_PATTERN */)
 	var EnableFeatureX_NoFlagIsPresent bool
 	flag.BoolVar(&EnableFeatureX_NoFlagIsPresent, "no-enable-feature-x", false, "Set enable-feature-x to false")
 	flag.TextVar(&options.HostIP, "host-ip", options.HostIP, "The host IP address for the service. (env:\"FULLSET_HOST_IP\")" /* Env: FULLSET_HOST_IP */)
+	isExistingFieldToMakeOptionalNilInitially := options.ExistingFieldToMakeOptional == nil
+	var tempExistingFieldToMakeOptionalVal string
 	var defaultExistingFieldToMakeOptionalValForFlag string
 	if options.ExistingFieldToMakeOptional != nil {
 		defaultExistingFieldToMakeOptionalValForFlag = *options.ExistingFieldToMakeOptional
 	}
-	if options.ExistingFieldToMakeOptional == nil {
-		options.ExistingFieldToMakeOptional = new(string)
+	if isExistingFieldToMakeOptionalNilInitially {
+		flag.StringVar(&tempExistingFieldToMakeOptionalVal, "existing-field-to-make-optional", "", "Example of an existing field made optional. (env:\"FULLSET_OPTIONAL_EXISTING\")" /* Env: FULLSET_OPTIONAL_EXISTING */)
+	} else {
+		flag.StringVar(options.ExistingFieldToMakeOptional, "existing-field-to-make-optional", defaultExistingFieldToMakeOptionalValForFlag, "Example of an existing field made optional. (env:\"FULLSET_OPTIONAL_EXISTING\")" /* Env: FULLSET_OPTIONAL_EXISTING */)
 	}
-	flag.StringVar(options.ExistingFieldToMakeOptional, "existing-field-to-make-optional", defaultExistingFieldToMakeOptionalValForFlag, "Example of an existing field made optional. (env:\"FULLSET_OPTIONAL_EXISTING\")" /* Env: FULLSET_OPTIONAL_EXISTING */)
 
 	// 4. Parse.
 	flag.Parse()
@@ -292,6 +301,17 @@ Defaults to "output" if not specified by the user.` /* Original Default: output,
 
 	if EnableFeatureX_NoFlagIsPresent {
 		options.EnableFeatureX = false
+	}
+
+	// 6. Assign values for initially nil pointers if flags were explicitly set
+	if isAgeNilInitially && isFlagExplicitlySet["age"] {
+		options.Age = &tempAgeVal
+	}
+	if isOptionalToggleNilInitially && isFlagExplicitlySet["optional-toggle"] {
+		options.OptionalToggle = &tempOptionalToggleVal
+	}
+	if isExistingFieldToMakeOptionalNilInitially && isFlagExplicitlySet["existing-field-to-make-optional"] {
+		options.ExistingFieldToMakeOptional = &tempExistingFieldToMakeOptionalVal
 	}
 
 	// 5. Perform required checks (excluding booleans).

--- a/examples/hello/main.go
+++ b/examples/hello/main.go
@@ -66,6 +66,8 @@ Flags:
 	flag.Parse()
 	flag.Visit(func(f *flag.Flag) { isFlagExplicitlySet[f.Name] = true })
 
+	// 6. Assign values for initially nil pointers if flags were explicitly set
+
 	// 5. Perform required checks (excluding booleans).
 
 	initialDefaultConfigFile := ""

--- a/internal/codegen/main_generator.go
+++ b/internal/codegen/main_generator.go
@@ -289,29 +289,49 @@ func main() {
 					sb.WriteString(fmt.Sprintf("	flag.BoolVar(&options.%s, %q, options.%s, %s %s)\n", opt.Name, kebabCaseName, opt.Name, formatHelpText(opt.HelpText), helpComment))
 				}
 			case "*string":
+				sb.WriteString(fmt.Sprintf("	is%sNilInitially := options.%s == nil\n", opt.Name, opt.Name))
+				sb.WriteString(fmt.Sprintf("	var temp%sVal %s\n", opt.Name, strings.TrimPrefix(opt.TypeName, "*")))
 				sb.WriteString(fmt.Sprintf("	var default%sValForFlag string\n", opt.Name))
 				sb.WriteString(fmt.Sprintf("	if options.%s != nil { default%sValForFlag = *options.%s }\n", opt.Name, opt.Name, opt.Name))
-				sb.WriteString(fmt.Sprintf("	if options.%s == nil { options.%s = new(string) }\n", opt.Name, opt.Name))
-				sb.WriteString(fmt.Sprintf("	flag.StringVar(options.%s, %q, default%sValForFlag, %s %s)\n", opt.Name, kebabCaseName, opt.Name, formatHelpText(opt.HelpText), helpComment))
+				// Line removed: sb.WriteString(fmt.Sprintf("	if options.%s == nil { options.%s = new(string) }\n", opt.Name, opt.Name))
+				sb.WriteString(fmt.Sprintf("	if is%sNilInitially {\n", opt.Name))
+				sb.WriteString(fmt.Sprintf("		flag.StringVar(&temp%sVal, %q, \"\", %s %s)\n", opt.Name, kebabCaseName, formatHelpText(opt.HelpText), helpComment))
+				sb.WriteString(fmt.Sprintf("	} else {\n"))
+				sb.WriteString(fmt.Sprintf("		flag.StringVar(options.%s, %q, default%sValForFlag, %s %s)\n", opt.Name, kebabCaseName, opt.Name, formatHelpText(opt.HelpText), helpComment))
+				sb.WriteString(fmt.Sprintf("	}\n"))
 			case "*int":
+				sb.WriteString(fmt.Sprintf("	is%sNilInitially := options.%s == nil\n", opt.Name, opt.Name))
+				sb.WriteString(fmt.Sprintf("	var temp%sVal %s\n", opt.Name, strings.TrimPrefix(opt.TypeName, "*")))
 				sb.WriteString(fmt.Sprintf("	var default%sValForFlag int\n", opt.Name))
 				sb.WriteString(fmt.Sprintf("	if options.%s != nil { default%sValForFlag = *options.%s }\n", opt.Name, opt.Name, opt.Name))
-				sb.WriteString(fmt.Sprintf("	if options.%s == nil { options.%s = new(int) }\n", opt.Name, opt.Name))
-				sb.WriteString(fmt.Sprintf("	flag.IntVar(options.%s, %q, default%sValForFlag, %s %s)\n", opt.Name, kebabCaseName, opt.Name, formatHelpText(opt.HelpText), helpComment))
+				// Line removed: sb.WriteString(fmt.Sprintf("	if options.%s == nil { options.%s = new(int) }\n", opt.Name, opt.Name))
+				sb.WriteString(fmt.Sprintf("	if is%sNilInitially {\n", opt.Name))
+				sb.WriteString(fmt.Sprintf("		flag.IntVar(&temp%sVal, %q, 0, %s %s)\n", opt.Name, kebabCaseName, formatHelpText(opt.HelpText), helpComment))
+				sb.WriteString(fmt.Sprintf("	} else {\n"))
+				sb.WriteString(fmt.Sprintf("		flag.IntVar(options.%s, %q, default%sValForFlag, %s %s)\n", opt.Name, kebabCaseName, opt.Name, formatHelpText(opt.HelpText), helpComment))
+				sb.WriteString(fmt.Sprintf("	}\n"))
 			case "*bool":
+				sb.WriteString(fmt.Sprintf("	is%sNilInitially := options.%s == nil\n", opt.Name, opt.Name))
+				sb.WriteString(fmt.Sprintf("	var temp%sVal %s\n", opt.Name, strings.TrimPrefix(opt.TypeName, "*")))
 				sb.WriteString(fmt.Sprintf("	var default%sValForFlag bool\n", opt.Name))
 				sb.WriteString(fmt.Sprintf("	if options.%s != nil { default%sValForFlag = *options.%s }\n", opt.Name, opt.Name, opt.Name))
-				sb.WriteString(fmt.Sprintf("	if options.%s == nil { options.%s = new(bool) }\n", opt.Name, opt.Name))
-				sb.WriteString(fmt.Sprintf("	flag.BoolVar(options.%s, %q, default%sValForFlag, %s %s)\n", opt.Name, kebabCaseName, opt.Name, formatHelpText(opt.HelpText), helpComment))
+				// Line removed: sb.WriteString(fmt.Sprintf("	if options.%s == nil { options.%s = new(bool) }\n", opt.Name, opt.Name))
+				sb.WriteString(fmt.Sprintf("	if is%sNilInitially {\n", opt.Name))
+				sb.WriteString(fmt.Sprintf("		flag.BoolVar(&temp%sVal, %q, false, %s %s)\n", opt.Name, kebabCaseName, formatHelpText(opt.HelpText), helpComment))
+				sb.WriteString(fmt.Sprintf("	} else {\n"))
+				sb.WriteString(fmt.Sprintf("		flag.BoolVar(options.%s, %q, default%sValForFlag, %s %s)\n", opt.Name, kebabCaseName, opt.Name, formatHelpText(opt.HelpText), helpComment))
+				sb.WriteString(fmt.Sprintf("	}\n"))
 			default:
 				if opt.IsTextUnmarshaler && opt.IsTextMarshaler {
 					if opt.IsPointer {
-						sb.WriteString(fmt.Sprintf(`
-	if options.%s == nil {
-		options.%s = new(%s)
-	}
-	flag.TextVar(options.%s, %q, options.%s, %s %s)
-`, opt.Name, opt.Name, strings.TrimPrefix(opt.TypeName, "*"), opt.Name, opt.CliName, opt.Name, formatHelpText(opt.HelpText), helpComment))
+						sb.WriteString(fmt.Sprintf("	is%sNilInitially := options.%s == nil\n", opt.Name, opt.Name))
+						sb.WriteString(fmt.Sprintf("	var temp%sVal %s\n", opt.Name, strings.TrimPrefix(opt.TypeName, "*")))
+						// Old block removed
+						sb.WriteString(fmt.Sprintf("	if is%sNilInitially {\n", opt.Name))
+						sb.WriteString(fmt.Sprintf("		flag.TextVar(&temp%sVal, %q, &temp%sVal, %s %s)\n", opt.Name, opt.CliName, opt.Name, formatHelpText(opt.HelpText), helpComment))
+						sb.WriteString(fmt.Sprintf("	} else {\n"))
+						sb.WriteString(fmt.Sprintf("		flag.TextVar(options.%s, %q, options.%s, %s %s)\n", opt.Name, opt.CliName, opt.Name, formatHelpText(opt.HelpText), helpComment))
+						sb.WriteString(fmt.Sprintf("	}\n"))
 					} else {
 						sb.WriteString(fmt.Sprintf("	flag.TextVar(&options.%s, %q, options.%s, %s %s)\n", opt.Name, opt.CliName, opt.Name, formatHelpText(opt.HelpText), helpComment))
 					}
@@ -338,6 +358,40 @@ func main() {
 		options.%s = false
 	}
 `, opt.Name, opt.Name))
+			}
+		}
+
+		sb.WriteString(`
+
+	// 6. Assign values for initially nil pointers if flags were explicitly set
+`)
+		// This loop iterates through cmdMeta.Options to generate the assignment logic
+		for _, opt := range cmdMeta.Options {
+			flagKeyForCheck := ""
+			isRelevantPointer := false
+
+			if opt.IsPointer && opt.IsTextUnmarshaler {
+				flagKeyForCheck = opt.CliName
+				if flagKeyForCheck == "" { // Fallback if CliName was empty
+					flagKeyForCheck = stringutils.ToKebabCase(opt.Name)
+				}
+				isRelevantPointer = true
+			} else {
+				switch opt.TypeName {
+				case "*string", "*int", "*bool":
+					flagKeyForCheck = stringutils.ToKebabCase(opt.Name)
+					isRelevantPointer = true
+				default:
+					// Not a pointer type this logic handles
+					isRelevantPointer = false // Explicitly
+				}
+			}
+
+			if isRelevantPointer { // Check isRelevantPointer
+				// Ensure is%sNilInitially and temp%sVal are in scope from flag setup
+				sb.WriteString(fmt.Sprintf("	if is%sNilInitially && isFlagExplicitlySet[%q] {\n", opt.Name, flagKeyForCheck))
+				sb.WriteString(fmt.Sprintf("		options.%s = &temp%sVal\n", opt.Name, opt.Name))
+				sb.WriteString(fmt.Sprintf("	}\n"))
 			}
 		}
 


### PR DESCRIPTION
Previously, pointer type flags in generated CLI code were incorrectly initialized with zero values if no corresponding flag was provided at runtime. This was due to the codegen logic unconditionally creating new instances for nil pointer option fields before flag parsing.

This commit modifies `internal/codegen/main_generator.go` to:
1. Introduce temporary variables for pointer option fields that are initially nil (after NewOptions() and env var processing).
2. Conditionally register flags using these temporary variables.
3. Add a post-parse step to assign the temporary variable's value to the actual option field only if the flag was explicitly set.

This ensures that if a pointer flag is not provided, and its corresponding option field had no default and was not set by an environment variable, the field remains nil as intended.

The changes include:
- Updated flag registration logic for *string, *int, *bool, and pointer TextUnmarshaler types.
- A new code block after flag parsing for conditional assignment.
- Added a new test `TestGenerateMain_PointerFlagsNilHandling` to specifically verify this behavior.
- Updated `TestGenerateMain_EnvVarPrecendenceStrategy` to align with the new pointer handling logic.
- Regenerated `examples/fullset/main.go` using `make examples-emit`.
- Ran `make format` and validated the code to ensure code quality and that all tests pass.