### PR TITLE
Fix: Avoid redundant default value assignments in codegen

### DIFF
--- a/examples/hello/main.go
+++ b/examples/hello/main.go
@@ -48,9 +48,6 @@ Flags:
 
 	// The following block populates the fields of the options struct.
 	// This logic is only executed if no InitializerFunc is provided.
-	options.Version = false
-	options.Help = false
-	options.ConfigFile = ""
 
 	// 2. Override with environment variable values.
 	// This section assumes 'options' is already initialized.

--- a/internal/codegen/main_generator.go
+++ b/internal/codegen/main_generator.go
@@ -109,37 +109,38 @@ func main() {
 			for _, opt := range cmdMeta.Options {
 				switch opt.TypeName {
 				case "string":
-					defaultValueStr := `""`
+					// If opt.DefaultValue is nil, this assignment is skipped.
+					// options.FieldName will retain its zero value ("") from new(OptionsType).
 					if opt.DefaultValue != nil {
-						valStr := fmt.Sprintf("%v", opt.DefaultValue) // Get string representation
-						if valStr != "" {                             // Only quote if not empty after string conversion
+						valStr := fmt.Sprintf("%v", opt.DefaultValue)
+						defaultValueStr := `""` // Default for empty string after conversion
+						if valStr != "" {
 							defaultValueStr = fmt.Sprintf("%q", valStr)
 						}
-						// If opt.DefaultValue was nil or an empty string, defaultValueStr remains `""`
+						sb.WriteString(fmt.Sprintf("	options.%s = %s\n", opt.Name, defaultValueStr))
 					}
-					sb.WriteString(fmt.Sprintf("	options.%s = %s\n", opt.Name, defaultValueStr))
 				case "int":
-					defaultValueStr := "0"
 					if opt.DefaultValue != nil {
+						defaultValueStr := "0" // Default to 0
 						if dvInt, ok := opt.DefaultValue.(int); ok {
-							defaultValueStr = fmt.Sprintf("%d", dvInt) // Use %d for int
-						} else { // Not an int but not nil - this path should ideally not be taken if metadata is correct
+							defaultValueStr = fmt.Sprintf("%d", dvInt)
+						} else {
+							// Attempt to format non-int default value, though this path is less ideal
 							defaultValueStr = fmt.Sprintf("%v", opt.DefaultValue)
 						}
+						sb.WriteString(fmt.Sprintf("	options.%s = %s\n", opt.Name, defaultValueStr))
 					}
-					// If opt.DefaultValue was nil, defaultValueStr remains "0"
-					sb.WriteString(fmt.Sprintf("	options.%s = %s\n", opt.Name, defaultValueStr))
 				case "bool":
-					defaultValueStr := "false"
 					if opt.DefaultValue != nil {
+						defaultValueStr := "false" // Default to false
 						if dvBool, ok := opt.DefaultValue.(bool); ok {
-							defaultValueStr = fmt.Sprintf("%t", dvBool) // Use %t for bool
-						} else { // Not a bool but not nil
+							defaultValueStr = fmt.Sprintf("%t", dvBool)
+						} else {
+							// Attempt to format non-bool default value
 							defaultValueStr = fmt.Sprintf("%v", opt.DefaultValue)
 						}
+						sb.WriteString(fmt.Sprintf("	options.%s = %s\n", opt.Name, defaultValueStr))
 					}
-					// If opt.DefaultValue was nil, defaultValueStr remains "false"
-					sb.WriteString(fmt.Sprintf("	options.%s = %s\n", opt.Name, defaultValueStr))
 				case "*string":
 					sb.WriteString(fmt.Sprintf("	options.%s = new(string)\n", opt.Name))
 					if opt.DefaultValue != nil {


### PR DESCRIPTION
When no initializer function is provided and an option has no explicit default value, the generated code was unnecessarily assigning the zero value (e.g., "", 0, false) to non-pointer option fields. This was redundant because the 'new(OptionsType)' call already zero-initializes these fields.

This commit modifies the code generator to skip these assignments for string, int, and bool types if 'opt.DefaultValue' is nil. The behavior for pointer types and for non-pointer types with explicit default values remains unchanged.

The 'make examples-emit' command has been run to update the generated examples.