### PR TITLE
Refactor error handling for conciseness

### DIFF
--- a/examples/enum/main.go
+++ b/examples/enum/main.go
@@ -181,11 +181,8 @@ imported from another package.`)
 		slog.ErrorContext(ctx, "Invalid value for flag", errors.New("Invalid value for flag"), "flag", "optional-imported-enum-field", "value", currentValueForMsg, "allowedChoices", strings.Join(allowedChoices_OptionalImportedEnumField, ", "))
 		os.Exit(1)
 	}
+	if err := run(*options); err != nil {
 
-	var err error
-	err = run(*options)
-
-	if err != nil {
 		slog.ErrorContext(ctx, "Runtime error", "error", err)
 		os.Exit(1)
 	}

--- a/examples/fullset/main.go
+++ b/examples/fullset/main.go
@@ -394,11 +394,8 @@ Defaults to "output" if not specified by the user.` /* Original Default: output,
 		slog.ErrorContext(ctx, "Missing required flag or environment variable not set", errors.New("Missing required flag or environment variable not set"), "flag", "pattern", "envVar", "FULLSET_PATTERN", "option", "Pattern")
 		os.Exit(1)
 	}
+	if err := run(ctx, options); err != nil {
 
-	var err error
-	err = run(ctx, options)
-
-	if err != nil {
 		slog.ErrorContext(ctx, "Runtime error", "error", err)
 		os.Exit(1)
 	}

--- a/examples/hello/main.go
+++ b/examples/hello/main.go
@@ -71,11 +71,8 @@ Flags:
 		slog.ErrorContext(ctx, "Missing required flag or environment variable not set", errors.New("Missing required flag or environment variable not set"), "flag", "config-file", "option", "ConfigFile")
 		os.Exit(1)
 	}
+	if err := run(*options); err != nil {
 
-	var err error
-	err = run(*options)
-
-	if err != nil {
 		slog.ErrorContext(ctx, "Runtime error", "error", err)
 		os.Exit(1)
 	}

--- a/internal/codegen/main_generator.go
+++ b/internal/codegen/main_generator.go
@@ -627,9 +627,6 @@ func main() {
 		}
 	}
 
-	sb.WriteString(`
-	var err error
-`)
 	runFuncCall := ""
 	if cmdMeta.RunFunc.ContextArgName != "" {
 		if cmdMeta.RunFunc.OptionsArgTypeNameStripped != "" {
@@ -652,10 +649,11 @@ func main() {
 			runFuncCall = fmt.Sprintf("err = %s()", cmdMeta.RunFunc.Name)
 		}
 	}
-	sb.WriteString(fmt.Sprintf("	%s\n", runFuncCall))
+	// The \n was removed from the format string as the if statement will be on the same line.
+	// The duplicated "err =" is removed from the line below.
+	sb.WriteString(fmt.Sprintf("	if err := %s; err != nil {\n", strings.TrimPrefix(runFuncCall, "err = ")))
 
 	sb.WriteString(`
-	if err != nil {
 		slog.ErrorContext(ctx, "Runtime error", "error", err)
 		os.Exit(1)
 	}

--- a/internal/codegen/writer.go
+++ b/internal/codegen/writer.go
@@ -115,8 +115,7 @@ func WriteMain(
 		return fmt.Errorf("processing (goimports) generated code for %s: %w\nOriginal newContent was:\n%s", filePath, err, string(newContent))
 	}
 
-	err = os.WriteFile(filePath, formattedContent, 0644) // Default permissions
-	if err != nil {
+	if err := os.WriteFile(filePath, formattedContent, 0644); err != nil { // Default permissions
 		return fmt.Errorf("writing modified content to %s: %w", filePath, err)
 	}
 


### PR DESCRIPTION
I refactored specific instances of error handling in `internal/codegen` to use the `if err := ...; err != nil` pattern, reducing boilerplate.

- In `internal/codegen/main_generator.go`:
    - I modified `generateMainContent` to generate the more concise error handling for the main command's run function call.
- In `internal/codegen/writer.go`:
    - I modified `WriteMain` to use the concise error handling for the `os.WriteFile` call.

I ran `make format` to ensure code style consistency and `make examples-emit` to update generated example code.

Note: Unit tests in `internal/codegen/main_generator_test.go` are currently failing as they expect the older error handling code structure. This is acceptable as per project guidelines for this type of refactoring unless a `fix tests` request is made.