### PR TITLE
Fix: Correctly scan default values for pointer types

### DIFF
--- a/examples/fullset/scan-result.json
+++ b/examples/fullset/scan-result.json
@@ -200,7 +200,7 @@ analyzer: warning: error checking TextMarshaler for field Features type []string
       "IsPointer": true,
       "IsRequired": false,
       "EnvVar": "FULLSET_OPTIONAL_EXISTING",
-      "DefaultValue": null,
+      "DefaultValue": "was set by default",
       "EnumValues": null,
       "IsTextUnmarshaler": false,
       "IsTextMarshaler": false,

--- a/internal/interpreter/interpreter.go
+++ b/internal/interpreter/interpreter.go
@@ -156,22 +156,92 @@ func extractMarkerInfo(
 		slog.InfoContext(ctx, fmt.Sprintf("Interpreting goat.Default for field %s (current Pkg: %s)", optMeta.Name, currentPkgPath))
 		if len(callExpr.Args) > 0 {
 			// Default value is the first argument
-			defaultEvalResult := astutils.EvaluateArg(ctx, callExpr.Args[0])
-			if defaultEvalResult.IdentifierName == "" { // If it's a literal or directly evaluatable value
-				optMeta.DefaultValue = defaultEvalResult.Value
-				slog.InfoContext(ctx, fmt.Sprintf("  Default value: %v", optMeta.DefaultValue))
-			} else { // Default value is an identifier
-				slog.InfoContext(ctx, fmt.Sprintf("  Default value for field %s is an identifier '%s' (pkg '%s'). Attempting resolution.", optMeta.Name, defaultEvalResult.IdentifierName, defaultEvalResult.PkgName))
-				// defaultEvalResult already contains IdentifierName and PkgName
-				// fileAst is the AST of the file where goat.Default is called
-				// currentPkgPath is the import path of this file
-				resolvedStrVal, success := resolveEvalResultToEnumString(ctx, defaultEvalResult, loader, currentPkgPath, fileAst)
-				if success {
-					optMeta.DefaultValue = resolvedStrVal
-					slog.DebugContext(ctx, fmt.Sprintf("Successfully resolved identifier default value: %v", optMeta.DefaultValue))
+			defaultArgExpr := callExpr.Args[0]
+			defaultEvalResult := astutils.EvaluateArg(ctx, defaultArgExpr)
+
+			// Check if the option field itself is a pointer type
+			isPointerField := optMeta.IsPointer
+
+			if isPointerField {
+				slog.InfoContext(ctx, fmt.Sprintf("  Field %s is a pointer type (TypeName: %s). Attempting to extract underlying default value.", optMeta.Name, optMeta.TypeName))
+				// If the field is a pointer, we want the underlying value.
+				// Case 1: Argument is a call to a helper function, e.g., stringPtr("value")
+				if innerCall, ok := defaultArgExpr.(*ast.CallExpr); ok {
+					slog.InfoContext(ctx, fmt.Sprintf("  Default for pointer field %s is via helper call: %s", optMeta.Name, astutils.ExprToTypeName(innerCall.Fun)))
+					if len(innerCall.Args) > 0 {
+						innerArgEvalResult := astutils.EvaluateArg(ctx, innerCall.Args[0])
+						if innerArgEvalResult.IdentifierName == "" { // Literal or directly evaluatable
+							optMeta.DefaultValue = innerArgEvalResult.Value
+							slog.InfoContext(ctx, fmt.Sprintf("  Default value (from pointer helper call arg): %v for field %s", optMeta.DefaultValue, optMeta.Name))
+						} else { // Argument to helper is an identifier
+							slog.InfoContext(ctx, fmt.Sprintf("  Argument to pointer helper for field %s is identifier '%s' (pkg '%s'). Attempting resolution.", optMeta.Name, innerArgEvalResult.IdentifierName, innerArgEvalResult.PkgName))
+							resolvedVal, success := resolveEvalResultToEnumString(ctx, innerArgEvalResult, loader, currentPkgPath, fileAst) // Using existing resolver
+							if success {
+								optMeta.DefaultValue = resolvedVal
+								slog.InfoContext(ctx, fmt.Sprintf("  Successfully resolved identifier (from pointer helper arg) for field %s: %v", optMeta.Name, optMeta.DefaultValue))
+							} else {
+								slog.WarnContext(ctx, fmt.Sprintf("  Failed to resolve identifier (from pointer helper arg) '%s' for field %s. DefaultValue will be nil.", innerArgEvalResult.IdentifierName, optMeta.Name))
+								optMeta.DefaultValue = nil
+							}
+						}
+					} else {
+						slog.WarnContext(ctx, fmt.Sprintf("  Pointer helper call for field %s has no arguments. Using raw eval of the call itself: %v", optMeta.Name, defaultEvalResult.Value))
+						optMeta.DefaultValue = defaultEvalResult.Value // Fallback to whatever EvaluateArg made of the call itself
+					}
+				} else if unaryExpr, ok := defaultArgExpr.(*ast.UnaryExpr); ok && unaryExpr.Op == token.AND {
+					// Case 2: Argument is an address-of expression, e.g., &myVar or &"literal" (if "literal" was a const/var)
+					slog.InfoContext(ctx, fmt.Sprintf("  Default for pointer field %s is via address-of operator (&). Evaluating inner expression.", optMeta.Name))
+					valueInsideAddrOf := astutils.EvaluateArg(ctx, unaryExpr.X)
+					if valueInsideAddrOf.IdentifierName == "" { // Literal or directly evaluatable
+						optMeta.DefaultValue = valueInsideAddrOf.Value
+						slog.InfoContext(ctx, fmt.Sprintf("  Default value (from &expr): %v for field %s", optMeta.DefaultValue, optMeta.Name))
+					} else { // Inner part of &expr is an identifier
+						slog.InfoContext(ctx, fmt.Sprintf("  Inner expression of & for field %s is identifier '%s' (pkg '%s'). Attempting resolution.", optMeta.Name, valueInsideAddrOf.IdentifierName, valueInsideAddrOf.PkgName))
+						resolvedVal, success := resolveEvalResultToEnumString(ctx, valueInsideAddrOf, loader, currentPkgPath, fileAst) // Using existing resolver
+						if success {
+							optMeta.DefaultValue = resolvedVal
+							slog.InfoContext(ctx, fmt.Sprintf("  Successfully resolved identifier (from &expr) for field %s: %v", optMeta.Name, optMeta.DefaultValue))
+						} else {
+							slog.WarnContext(ctx, fmt.Sprintf("  Failed to resolve identifier (from &expr) '%s' for field %s. DefaultValue will be nil.", valueInsideAddrOf.IdentifierName, optMeta.Name))
+							optMeta.DefaultValue = nil
+						}
+					}
 				} else {
-					slog.DebugContext(ctx, fmt.Sprintf("Failed to resolve identifier default value for '%s'. DefaultValue will be nil.", defaultEvalResult.IdentifierName))
-					optMeta.DefaultValue = nil
+					// Case 3: Field is a pointer, but default arg is not a helper call or &expr.
+					// It might be a direct variable that is already a pointer, or a literal that EvaluateArg handled.
+					// The goal is to store the *dereferenced* value, but if it's just a variable, resolving its pointed-to value here is complex.
+					// Trust defaultEvalResult for now, which might be the pointer value itself or what EvaluateArg could determine.
+					// This path means we are not explicitly dereferencing a known pointer-creating pattern here.
+					slog.InfoContext(ctx, fmt.Sprintf("  Default for pointer field %s is (value: %v, ident: '%s', pkg: '%s'). Using direct evaluation or attempting resolution if identifier.", optMeta.Name, defaultEvalResult.Value, defaultEvalResult.IdentifierName, defaultEvalResult.PkgName))
+					if defaultEvalResult.IdentifierName == "" {
+						optMeta.DefaultValue = defaultEvalResult.Value // This might be nil if original was `var p *string; ... Default(p)`
+						slog.InfoContext(ctx, fmt.Sprintf("  Default value (direct for pointer field): %v for field %s", optMeta.DefaultValue, optMeta.Name))
+					} else {
+						slog.InfoContext(ctx, fmt.Sprintf("  Default value for pointer field %s is an identifier '%s' (pkg '%s'). Attempting resolution.", optMeta.Name, defaultEvalResult.IdentifierName, defaultEvalResult.PkgName))
+						resolvedVal, success := resolveEvalResultToEnumString(ctx, defaultEvalResult, loader, currentPkgPath, fileAst)
+						if success {
+							optMeta.DefaultValue = resolvedVal // This would be the string value if resolved.
+							slog.InfoContext(ctx, fmt.Sprintf("  Successfully resolved identifier for pointer field %s: %v", optMeta.Name, optMeta.DefaultValue))
+						} else {
+							slog.WarnContext(ctx, fmt.Sprintf("  Failed to resolve identifier '%s' for pointer field %s. DefaultValue will be nil.", defaultEvalResult.IdentifierName, optMeta.Name))
+							optMeta.DefaultValue = nil
+						}
+					}
+				}
+			} else { // Field is not a pointer type (original logic)
+				if defaultEvalResult.IdentifierName == "" { // If it's a literal or directly evaluatable value
+					optMeta.DefaultValue = defaultEvalResult.Value
+					slog.InfoContext(ctx, fmt.Sprintf("  Default value: %v for field %s", optMeta.DefaultValue, optMeta.Name))
+				} else { // Default value is an identifier
+					slog.InfoContext(ctx, fmt.Sprintf("  Default value for field %s is an identifier '%s' (pkg '%s'). Attempting resolution.", optMeta.Name, defaultEvalResult.IdentifierName, defaultEvalResult.PkgName))
+					resolvedStrVal, success := resolveEvalResultToEnumString(ctx, defaultEvalResult, loader, currentPkgPath, fileAst)
+					if success {
+						optMeta.DefaultValue = resolvedStrVal
+						slog.DebugContext(ctx, fmt.Sprintf("Successfully resolved identifier default value for field %s: %v", optMeta.Name, optMeta.DefaultValue))
+					} else {
+						slog.DebugContext(ctx, fmt.Sprintf("Failed to resolve identifier default value for '%s' (field %s). DefaultValue will be nil.", defaultEvalResult.IdentifierName, optMeta.Name))
+						optMeta.DefaultValue = nil
+					}
 				}
 			}
 


### PR DESCRIPTION
The `goat scan` command was previously not correctly identifying the default value for option fields that are pointer types and initialized using `goat.Default()` with a helper function that returns a pointer (e.g., `goat.Default(stringPtr("value"))`). The `scan-result.json` would incorrectly show `null` as the `DefaultValue`.

This commit modifies `internal/interpreter/interpreter.go` in the `extractMarkerInfo` function. When processing a `goat.Default` call for a field where `OptionMetadata.IsPointer` is true, the code now inspects the argument to `goat.Default`.
- If the argument is a call to a helper function (e.g., `stringPtr("val")`), it evaluates the argument of this inner call to get the actual default.
- If the argument is an address-of expression (e.g., `&myVar`), it evaluates the inner expression (`myVar`).

This ensures that the actual underlying default value is stored in `OptionMetadata.DefaultValue` in the `scan-result.json`.

The fix was verified by running `goat scan` on the `examples/fullset` project, where the `ExistingFieldToMakeOptional *string` field, initialized with `goat.Default(stringPtr("was set by default"))`, now correctly shows `"was set by default"` as its `DefaultValue` in the generated `scan-result.json`.